### PR TITLE
Trying Conda

### DIFF
--- a/.github/workflows/python-test-package.yml
+++ b/.github/workflows/python-test-package.yml
@@ -4,17 +4,17 @@
 name: Python package
 
 on:
-  workflow_dispatch:
-    branches: [ $default-branch ]
   push:
-    branches: [ $default-branch ]
-  pull_request:
-    branches: [ $default-branch ]
+    branches:
+      - conda-1
 
 jobs:
   build:
 
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
     strategy:
       fail-fast: false
       matrix:
@@ -22,15 +22,35 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+    - name: Cache conda
+      uses: actions/cache@v2
+      env:
+        # Increase this value to reset cache if environment.yml has not changed
+        CACHE_NUMBER: 0
       with:
+        path: ~/conda_pkgs_dir
+        key:
+          ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{
+          hashFiles('environment.yml') }}
+    - uses: conda-incubator/setup-miniconda@v2
+      with:
+        activate-environment: geofabrics
+        environment-file: environment.yml
+        auto-activate-base: false
+        channels: conda-forge
+        channel-priority: strict
+        use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+        mamba-version: "*"
+        # condarc-file: etc/example-condarc.yml
+    - run: |
+        conda info
+        conda list
+        conda config --show-sources
+        conda config --show
+    - name: Install test dependencies
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install flake8 pytest
-        if [ -f requirements.txt ]; then pip install -- -DPDAL_DIR=/usr/lib/cmake/ -r requirements.txt; fi
+        mamba install flake8 pytest
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/python-test-package.yml
+++ b/.github/workflows/python-test-package.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Hi @rosepearson !

I got it working in a local Docker container with unstable Debian. Then I realized you wanted to have multiple versions of Python too! While that's doable too, maintaining the Docker image wouldn't be fun, and you could end up spending time troubleshooting the Docker containers (time that I think you'd prefer to use for other fun parts of GeoFabrics :) )

Maybe Conda will be the only way forward? And tell users that the `pip` installation fails due to `pdal` versions in the LTS release of Ubuntu (may work in other distros).

I've set up a quick Conda + GH Actions, but it's failing now on some tests. It failed on 3.6, so I switched to 3.7, 3.8, 3.9 thinking that would solve the problem... but it appears to be missing something else? https://github.com/kinow/GeoFabrics/actions/runs/1048519100