### PR TITLE
22 ensure correct datums

### DIFF
--- a/environment_linux.yml
+++ b/environment_linux.yml
@@ -8,8 +8,6 @@ dependencies:
   - pip
   - gdal=3.2.2 # pin to ensure consistent grid alignment PDAL writers.gdal
   - geopandas
-  - requests
-  - boto3
   - rioxarray
   - pdal=2.2
   - python-pdal=2.4=py38h1fd1430_1 # pin version so compatible with PDAL 2.2 but for Linux

--- a/environment_linux.yml
+++ b/environment_linux.yml
@@ -12,15 +12,7 @@ dependencies:
   - pdal=2.2
   - python-pdal=2.4=py38h1fd1430_1 # pin version so compatible with PDAL 2.2 but for Linux
   - python-dotenv
-  - matplotlib
-  - ipykernel
-  - ipython
-  - ipython_genutils
-  - jupyter_client
-  - jupyter_core
   - pytest
-  - spyder
-  - spyder-kernels
   - pip:
     - git+https://github.com/niwa/geoapis
 

--- a/environment_windows.yml
+++ b/environment_windows.yml
@@ -9,8 +9,6 @@ dependencies:
   - pip
   - gdal
   - geopandas
-  - requests
-  - boto3
   - rioxarray
   - pdal
   - python-pdal

--- a/src/geofabrics/__init__.py
+++ b/src/geofabrics/__init__.py
@@ -4,4 +4,4 @@ Created on Thu Jul  1 09:57:30 2021
 
 @author: pearsonra
 """
-__version__ = "0.6.0"
+__version__ = "0.6.1"

--- a/src/geofabrics/dem.py
+++ b/src/geofabrics/dem.py
@@ -42,7 +42,7 @@ class ReferenceDem:
     def _set_up(self, exclusion_extent):
         """ Set DEM CRS and trim the DEM to size """
 
-        self._dem.rio.set_crs(self.catchment_geometry.crs)
+        self._dem.rio.set_crs(self.catchment_geometry.horizontal_crs)
 
         if exclusion_extent is not None:
             exclusion_extent = geopandas.clip(exclusion_extent, self.catchment_geometry.land_and_foreshore)
@@ -163,7 +163,7 @@ class DenseDem:
         empty_points = numpy.zeros([1], dtype=[('X', numpy.float64), ('Y', numpy.float64), ('Z', numpy.float64)])
         pdal_pipeline_instructions = [
             {"type":  "writers.gdal", "resolution": self.catchment_geometry.resolution,
-             "gdalopts": "a_srs=EPSG:" + str(self.catchment_geometry.crs),
+             "gdalopts": "a_srs=EPSG:" + str(self.catchment_geometry.horizontal_crs),
              "output_type": ["idw"], "filename": str(self._temp_dem_file),
              "origin_x": self.raster_origin[0], "origin_y": self.raster_origin[1],
              "width": self.raster_size[0], "height": self.raster_size[1]}
@@ -177,7 +177,7 @@ class DenseDem:
 
         with rioxarray.rioxarray.open_rasterio(str(self._temp_dem_file), masked=True) as dem_temp:
             dem_temp.load()
-            dem_temp.rio.set_crs(self.catchment_geometry.crs)
+            dem_temp.rio.set_crs(self.catchment_geometry.horizontal_crs)
 
         # check if the raster origin has been moved by PDAL writers.gdal
         raster_origin = [dem_temp.x.data.min() - self.catchment_geometry.resolution/2,
@@ -200,7 +200,7 @@ class DenseDem:
             self._temp_dem_file.unlink()
         pdal_pipeline_instructions = [
             {"type":  "writers.gdal", "resolution": self.catchment_geometry.resolution,
-             "gdalopts": f"a_srs=EPSG:{self.catchment_geometry.crs}", "output_type": [self.DENSE_BINNING],
+             "gdalopts": f"a_srs=EPSG:{self.catchment_geometry.horizontal_crs}", "output_type": [self.DENSE_BINNING],
              "filename": str(self._temp_dem_file),
              "window_size": window_size, "power": idw_power, "radius": radius,
              "origin_x": self.raster_origin[0], "origin_y": self.raster_origin[1],
@@ -232,7 +232,7 @@ class DenseDem:
         # load generated tile
         with rioxarray.rioxarray.open_rasterio(self._temp_dem_file, masked=True) as tile:
             tile.load()
-        tile.rio.set_crs(self.catchment_geometry.crs)
+        tile.rio.set_crs(self.catchment_geometry.horizontal_crs)
 
         # ensure the tile is lined up with the whole dense DEM - i.e. that that raster origin values match
         raster_origin = [tile.x.data.min() - self.catchment_geometry.resolution/2,

--- a/src/geofabrics/dem.py
+++ b/src/geofabrics/dem.py
@@ -42,7 +42,7 @@ class ReferenceDem:
     def _set_up(self, exclusion_extent):
         """ Set DEM CRS and trim the DEM to size """
 
-        self._dem.rio.set_crs(self.catchment_geometry.horizontal_crs)
+        self._dem.rio.set_crs(self.catchment_geometry.crs['horizontal'])
 
         if exclusion_extent is not None:
             exclusion_extent = geopandas.clip(exclusion_extent, self.catchment_geometry.land_and_foreshore)
@@ -163,7 +163,7 @@ class DenseDem:
         empty_points = numpy.zeros([1], dtype=[('X', numpy.float64), ('Y', numpy.float64), ('Z', numpy.float64)])
         pdal_pipeline_instructions = [
             {"type":  "writers.gdal", "resolution": self.catchment_geometry.resolution,
-             "gdalopts": "a_srs=EPSG:" + str(self.catchment_geometry.horizontal_crs),
+             "gdalopts": "a_srs=EPSG:" + str(self.catchment_geometry.crs['horizontal']),
              "output_type": ["idw"], "filename": str(self._temp_dem_file),
              "origin_x": self.raster_origin[0], "origin_y": self.raster_origin[1],
              "width": self.raster_size[0], "height": self.raster_size[1]}
@@ -177,7 +177,7 @@ class DenseDem:
 
         with rioxarray.rioxarray.open_rasterio(str(self._temp_dem_file), masked=True) as dem_temp:
             dem_temp.load()
-            dem_temp.rio.set_crs(self.catchment_geometry.horizontal_crs)
+            dem_temp.rio.set_crs(self.catchment_geometry.crs['horizontal'])
 
         # check if the raster origin has been moved by PDAL writers.gdal
         raster_origin = [dem_temp.x.data.min() - self.catchment_geometry.resolution/2,
@@ -200,7 +200,7 @@ class DenseDem:
             self._temp_dem_file.unlink()
         pdal_pipeline_instructions = [
             {"type":  "writers.gdal", "resolution": self.catchment_geometry.resolution,
-             "gdalopts": f"a_srs=EPSG:{self.catchment_geometry.horizontal_crs}", "output_type": [self.DENSE_BINNING],
+             "gdalopts": f"a_srs=EPSG:{self.catchment_geometry.crs['horizontal']}", "output_type": [self.DENSE_BINNING],
              "filename": str(self._temp_dem_file),
              "window_size": window_size, "power": idw_power, "radius": radius,
              "origin_x": self.raster_origin[0], "origin_y": self.raster_origin[1],
@@ -232,7 +232,7 @@ class DenseDem:
         # load generated tile
         with rioxarray.rioxarray.open_rasterio(self._temp_dem_file, masked=True) as tile:
             tile.load()
-        tile.rio.set_crs(self.catchment_geometry.horizontal_crs)
+        tile.rio.set_crs(self.catchment_geometry.crs['horizontal'])
 
         # ensure the tile is lined up with the whole dense DEM - i.e. that that raster origin values match
         raster_origin = [tile.x.data.min() - self.catchment_geometry.resolution/2,

--- a/src/geofabrics/geometry.py
+++ b/src/geofabrics/geometry.py
@@ -341,7 +341,7 @@ class TileInfo:
 
         column_name_matches = [name for name in column_names if "filename" == name.lower()]
         column_name_matches.extend([name for name in column_names if "file_name" == name.lower()])
-        print(column_name_matches)
+
         assert len(column_name_matches) == 1, "No single `file name` column detected in the tile file with" + \
             f" columns: {column_names}"
         self.file_name = column_name_matches[0]

--- a/src/geofabrics/geometry.py
+++ b/src/geofabrics/geometry.py
@@ -12,33 +12,33 @@ import typing
 
 
 class CatchmentGeometry:
-    """ A class defining all relevant regions as defined by polygons in a catchment
+    """ A class defining all relevant regions as defined by polygons in a catchment.
+
+    The CRS is a dictionary containing the EPSG code for a 'horizontal' and 'vertical' datum.
 
     Specifically, this defines polygon regions like 'land', 'foreshore', 'offshore', and ensures all regions are
     defined in the same CRS.
 
     The land, foreshore and offshore regions are clipped within the catchment, but do not overlap. The land is
     polygon is defined by a specified polygon which is clipped within the catchment. The foreshore is defined
-    as a 20m outward buffer from the land and within the catchment extents. The offshore region is any remaining
-    region within the catchment region and outside the land and foreshore polygons.
+    as a 'foreshore_buffer' x 'resolution' outward buffer from the land and within the catchment extents. The offshore
+    region is any remaining region within the catchment region and outside the land and foreshore polygons.
 
     It also supports functions for determining how much of a region is outside an exclusion zone. I.E. is outside
     `lidar_extents` see class method land_and_foreshore_without_lidar for an example.
 
-
     It is initalised with the catchment. The land must be added before the other regions (i.e. land, offshore,
     foreshore, etc) can be accessed. """
 
-    def __init__(self, catchment_file: typing.Union[str, pathlib.Path], horizontal_crs, vertical_crs, resolution,
-                 foreshore_buffer=2):
+    def __init__(self, catchment_file: typing.Union[str, pathlib.Path], crs: dict, resolution: float,
+                 foreshore_buffer: int = 2):
         self._catchment = geopandas.read_file(catchment_file)
-        self.horizontal_crs = horizontal_crs
-        self.vertical_crs = vertical_crs
+        self.crs = crs
         self.resolution = resolution
         self.foreshore_buffer = foreshore_buffer
 
         # set catchment CRS
-        self._catchment = self._catchment.to_crs(self.horizontal_crs)
+        self._catchment = self._catchment.to_crs(self.crs['horizontal'])
 
         # values set in setup once land has been specified
         self._land = None
@@ -50,14 +50,14 @@ class CatchmentGeometry:
     def _set_up(self):
         """ Define the main catchment regions and ensure the CRS is set for each region """
 
-        self._land = self._land.to_crs(self.horizontal_crs)
+        self._land = self._land.to_crs(self.crs['horizontal'])
 
         self._land = geopandas.clip(self._catchment, self._land)
 
         self._foreshore_and_offshore = geopandas.overlay(self.catchment, self.land, how='difference')
 
         self._land_and_foreshore = geopandas.GeoDataFrame(
-            index=[0], geometry=self.land.buffer(self.resolution * self.foreshore_buffer), crs=self.horizontal_crs)
+            index=[0], geometry=self.land.buffer(self.resolution * self.foreshore_buffer), crs=self.crs['horizontal'])
         self._land_and_foreshore = geopandas.clip(self.catchment, self._land_and_foreshore)
 
         self._foreshore = geopandas.overlay(self.land_and_foreshore, self.land, how='difference')
@@ -152,14 +152,14 @@ class CatchmentGeometry:
         # the foreshore and whatever lidar extents are offshore
         dense_data_extents = geopandas.GeoSeries(shapely.ops.cascaded_union([self.foreshore.loc[0].geometry,
                                                                              lidar_extents.loc[0].geometry]))
-        dense_data_extents = geopandas.GeoDataFrame(index=[0], geometry=dense_data_extents, crs=self.horizontal_crs)
+        dense_data_extents = geopandas.GeoDataFrame(index=[0], geometry=dense_data_extents, crs=self.crs['horizontal'])
         dense_data_extents = geopandas.clip(dense_data_extents, self.foreshore_and_offshore)
 
         # deflate this
         deflated_dense_data_extents = geopandas.GeoDataFrame(index=[0],
                                                              geometry=dense_data_extents.buffer(
                                                                  self.resolution * -1 * self.foreshore_buffer),
-                                                             crs=self.horizontal_crs)
+                                                             crs=self.crs['horizontal'])
 
         # get the difference between them
         offshore_dense_data_edge = geopandas.overlay(dense_data_extents, deflated_dense_data_extents, how='difference')
@@ -205,7 +205,7 @@ class BathymetryContours:
     def _set_up(self, exclusion_extent):
         """ Set CRS and clip to catchment """
 
-        self._contour = self._contour.to_crs(self.catchment_geometry.horizontal_crs)
+        self._contour = self._contour.to_crs(self.catchment_geometry.crs['horizontal'])
 
         if exclusion_extent is not None:
             exclusion_extent = geopandas.clip(exclusion_extent, self.catchment_geometry.offshore)
@@ -273,7 +273,7 @@ class BathymetryPoints:
     def _set_up(self, exclusion_extent):
         """ Set CRS and clip to catchment """
 
-        self._points = self._points.to_crs(self.catchment_geometry.horizontal_crs)
+        self._points = self._points.to_crs(self.catchment_geometry.crs['horizontal'])
 
         if exclusion_extent is not None:
             exclusion_extent = geopandas.clip(exclusion_extent, self.catchment_geometry.offshore)
@@ -333,7 +333,7 @@ class TileInfo:
     def _set_up(self):
         """ Set CRS and select all tiles partially within the catchment, and look up the file column name """
 
-        self._tile_info = self._tile_info.to_crs(self.catchment_geometry.horizontal_crs)
+        self._tile_info = self._tile_info.to_crs(self.catchment_geometry.crs['horizontal'])
         self._tile_info = geopandas.sjoin(self._tile_info, self.catchment_geometry.catchment)
         self._tile_info = self._tile_info.reset_index(drop=True)
 

--- a/src/geofabrics/lidar.py
+++ b/src/geofabrics/lidar.py
@@ -68,7 +68,7 @@ class CatchmentLidar:
         pdal_pipeline_instructions.append(
             {"type": "filters.crop", "polygon": str(self.catchment_geometry.catchment.loc[0].geometry)})
         pdal_pipeline_instructions.append({"type": "filters.hexbin"})
-        print(json.dumps(pdal_pipeline_instructions))
+
         # Load in LiDAR and perform operations
         self._pdal_pipeline = pdal.Pipeline(json.dumps(pdal_pipeline_instructions))
         self._pdal_pipeline.execute()

--- a/src/geofabrics/processor.py
+++ b/src/geofabrics/processor.py
@@ -63,12 +63,20 @@ class GeoFabricsGenerator:
             "'resolution' is not a key-word in the instructions"
         return self.instructions['instructions']['grid_params']['resolution']
 
-    def get_projection(self) -> float:
+    def get_crs(self, key: str) -> float:
         """ Return the CRS projection from the instruction file. Raise an error if not in the instructions. """
 
-        assert 'projection' in self.instructions['instructions'], \
-            "'projection' is not a key-word in the instructions"
-        return self.instructions['instructions']['projection']
+        defaults = {'horizontal': 2193, 'vertical': 7839}
+
+        assert 'crs' in self.instructions['instructions'], "'crs' is not a key-word in the instructions"
+
+        if key in self.instructions['instructions']['crs']:
+            return self.instructions['instructions']['crs'][key]
+        elif key in defaults.keys():
+            return defaults[key]
+        else:
+            assert False, f"The key `{key}` is both missing from instructions crs, and is not defined in the " + \
+                f"{defaults}"
 
     def get_instruction_general(self, key: str):
         """ Return the general instruction from the instruction file or return the default value if not specified in
@@ -187,9 +195,8 @@ class GeoFabricsGenerator:
         assert type(catchment_dirs) is not list, f"A list of catchment_boundary's is provided: {catchment_dirs}, " + \
             "where only one is supported."
         self.catchment_geometry = geometry.CatchmentGeometry(catchment_dirs,
-                                                             self.get_projection(),
-                                                             self.get_resolution(),
-                                                             foreshore_buffer=2)
+                                                             self.get_crs('horizontal'), self.get_crs('vertical'),
+                                                             self.get_resolution(), foreshore_buffer=2)
         land_dirs = self.get_vector_paths('land')
         assert len(land_dirs) == 1, f"{len(land_dirs)} catchment_boundary's provided, where only one is supported." + \
             f" Specficially land_dirs = {land_dirs}."

--- a/src/geofabrics/processor.py
+++ b/src/geofabrics/processor.py
@@ -108,7 +108,7 @@ class GeoFabricsGenerator:
         if "data_paths" in self.instructions['instructions'] and key in self.instructions['instructions']['data_paths']:
             # Key included in the data paths
             return True
-        elif "apis" in self.instructions['instructions'] and "linz" in self.instructions['instructions'] and \
+        elif "apis" in self.instructions['instructions'] and "linz" in self.instructions['instructions']['apis'] and \
                 key in self.instructions['instructions']['apis']['linz']:
             # Key included in the LINZ APIs
             return True

--- a/src/geofabrics/processor.py
+++ b/src/geofabrics/processor.py
@@ -163,7 +163,7 @@ class GeoFabricsGenerator:
                                                              verbose=True)
 
                 vector_instruction = self.instructions['instructions']['apis'][data_service][key]
-                geometry_type = vector_instruction['type'] if 'type' in vector_instruction else None
+                geometry_type = vector_instruction['geometry_name '] if 'geometry_name ' in vector_instruction else None
 
                 if verbose:
                     print(f"Downloading vector layers {vector_instruction['layers']} from the {data_service} data" +

--- a/src/geofabrics/processor.py
+++ b/src/geofabrics/processor.py
@@ -144,9 +144,8 @@ class GeoFabricsGenerator:
         # Check the instructions for LINZ hoster vector data
         data_services = {"linz": geoapis.vector.Linz, "lris": geoapis.vector.Lris}  # API name and geoapis class pairs
         for data_service in data_services.keys():
-            cache_dir = pathlib.Path(self.get_instruction_path('local_cache'))
             if self.check_apis(data_service) and key in self.instructions['instructions']['apis'][data_service]:
-
+                cache_dir = pathlib.Path(self.get_instruction_path('local_cache'))
                 api_key = self.instructions['instructions']['apis'][data_service]['key']
 
                 assert self.check_instruction_path('local_cache'), "Local cache file path must exist to specify the" + \

--- a/src/geofabrics/processor.py
+++ b/src/geofabrics/processor.py
@@ -86,8 +86,8 @@ class GeoFabricsGenerator:
             crs_dict['vertical'] = crs_instruction['vertical'] if 'vertical' in crs_instruction else \
                 defaults['vertical']
             if verbose:
-                print(f"The output CRS values of {crs_dict} will be used. If these are not as epected. Check both the" +
-                      " 'horizontal' and 'vertical' values are specified.")
+                print(f"The output CRS values of {crs_dict} will be used. If these are not as expected. Check both " +
+                      "the 'horizontal' and 'vertical' values are specified.")
             return crs_dict
 
     def get_instruction_general(self, key: str):
@@ -155,7 +155,7 @@ class GeoFabricsGenerator:
                 assert self.check_instruction_path('local_cache'), "Local cache file path must exist to specify the" + \
                     f" location to download vector data from the vector APIs: {data_services}"
                 assert self.catchment_geometry is not None, "The `self.catchment_directory` object must exist " + \
-                    "before avector is downloaded using `vector.Linz`"
+                    "before a vector is downloaded using `vector.Linz`"
 
                 # Instantiate object for downloading vectors from the data service. Download layers with the run method
                 vector_fetcher = data_services[data_service](api_key,

--- a/src/geofabrics/processor.py
+++ b/src/geofabrics/processor.py
@@ -238,6 +238,13 @@ class GeoFabricsGenerator:
         if (self.check_instruction_path('reference_dems') and
                 area_without_lidar > self.catchment_geometry.land_and_foreshore.area.sum() * area_threshold):
 
+            assert len(self.get_instruction_path('reference_dems')) == 1, \
+                f"{len(self.get_instruction_path('reference_dems'))} reference_dems specified, but only one supported" \
+                + f" currently. reference_dems: {self.get_instruction_path('reference_dems')}"
+
+            if verbose:
+                print(f"Incorporting background DEM: {self.get_instruction_path('reference_dems')}")
+
             # Load in background DEM - cut away within the LiDAR extents
             self.reference_dem = dem.ReferenceDem(self.get_instruction_path('reference_dems')[0],
                                                   self.catchment_geometry,
@@ -257,7 +264,10 @@ class GeoFabricsGenerator:
             bathy_contour_dirs = self.get_vector_paths('bathymetry_contours')
             assert len(bathy_contour_dirs) == 1, f"{len(bathy_contour_dirs)} bathymetry_contours's provided. " + \
                 f"Specficially {catchment_dirs}. Support has not yet been added for multiple datasets."
-            print(bathy_contour_dirs)
+
+            if verbose:
+                print(f"Incorporting Bathymetry: {bathy_contour_dirs}")
+
             # Load in bathymetry
             self.bathy_contours = geometry.BathymetryContours(
                 bathy_contour_dirs[0], self.catchment_geometry,

--- a/src/geofabrics/processor.py
+++ b/src/geofabrics/processor.py
@@ -76,7 +76,8 @@ class GeoFabricsGenerator:
             "should exist and is where the resolution and optionally the CRS of the output DEM is defined."
 
         if 'crs' not in self.instructions['instructions']['output']:
-            print(f"Warning: No output CRS values specified. We will instead be using the defaults: {defaults}.")
+            print("Warning: No output the coordinate system EPSG values specified. We will instead be using the " +
+                  f"defaults: {defaults}.")
             return defaults
         else:
             crs_instruction = self.instructions['instructions']['output']['crs']
@@ -86,8 +87,8 @@ class GeoFabricsGenerator:
             crs_dict['vertical'] = crs_instruction['vertical'] if 'vertical' in crs_instruction else \
                 defaults['vertical']
             if verbose:
-                print(f"The output CRS values of {crs_dict} will be used. If these are not as expected. Check both " +
-                      "the 'horizontal' and 'vertical' values are specified.")
+                print(f"The output the coordinate system EPSG values of {crs_dict} will be used. If these are not as " +
+                      "expected. Check both the 'horizontal' and 'vertical' values are specified.")
             return crs_dict
 
     def get_instruction_general(self, key: str):
@@ -206,15 +207,16 @@ class GeoFabricsGenerator:
                 dataset_crs = {'horizontal': dataset_instruction['crs']['horizontal'],
                                'vertical': dataset_instruction['crs']['vertical']}
                 if verbose:
-                    print(f"The LiDAR dataset {dataset_name} is assumed to have the source CRS: {dataset_crs} as " +
-                          "defined in the instruction file")
+                    print(f"The LiDAR dataset {dataset_name} is assumed to have the source coordinate system EPSG: " +
+                          f"{dataset_crs} as defined in the instruction file")
                 return dataset_crs
             else:
                 if verbose:
-                    print(f"The LiDAR dataset {dataset_name} will use the source CRS defined in its LAZ files")
+                    print(f"The LiDAR dataset {dataset_name} will use the source the coordinate system EPSG defined" +
+                          " in its LAZ files")
                 return None
         if verbose:
-            print(f"The LiDAR dataset {dataset_name} will use the source CRS defined in its LAZ files")
+            print(f"The LiDAR dataset {dataset_name} will use the source coordinate system EPSG from its LAZ files")
         return None
 
     def get_lidar_file_list(self, data_service, verbose: bool = False) -> dict:

--- a/src/main.py
+++ b/src/main.py
@@ -10,6 +10,7 @@ import argparse
 import rioxarray
 import numpy
 import matplotlib
+import time
 
 
 def parse_args():
@@ -31,8 +32,12 @@ def launch_processor(args):
         instructions = json.load(file_pointer)
 
     # run the pipeline
+    start_time = time.time()
     runner = processor.GeoFabricsGenerator(instructions)
     runner.run()
+    end_time = time.time()
+
+    print(f"Execution time is {end_time - start_time}")
 
     # load in benchmark DEM and compare - if specified in the instructions
     if 'benchmark_dem' in instructions['instructions']['data_paths']:

--- a/tests/test_processor_local_files/instruction.json
+++ b/tests/test_processor_local_files/instruction.json
@@ -3,7 +3,7 @@
 		"output": {
 			"crs": {
 				"horizontal": 2193,
-				"vertical": ""
+				"vertical": 7839
 			},
 			"grid_params": {
 				"resolution": 10

--- a/tests/test_processor_local_files/instruction.json
+++ b/tests/test_processor_local_files/instruction.json
@@ -1,24 +1,26 @@
 {"instructions": 
-  {
-    "crs": {
-		"horizontal": 2193,
-		"vertical": ""
-	},
-	"grid_params": {
-      "resolution": 10
-    },
-    "data_paths": {
-      "catchment_boundary": "tests/test_processor_local_files/data/catchment_boundary.zip",
-	  "land": "tests/test_processor_local_files/data/land.zip",
-	  "lidars": ["tests/test_processor_local_files/data/lidar.laz"],
-	  "reference_dems": ["tests/test_processor_local_files/data/reference_dem.nc"],
-	  "bathymetry_contours": ["tests/test_processor_local_files/data/bathymetry.zip"],
-	  "temp_raster": "tests/test_processor_local_files/data/temp_dense_dem.tif",
-	  "result_dem": "tests/test_processor_local_files/data/test_dem.nc",
-	  "benchmark_dem": "tests/test_processor_local_files/data/benchmark_dem.nc"
-    },
-    "general": {
-      "set_dem_shoreline": "True"
-    }
-  }
+	{
+		"output": {
+			"crs": {
+				"horizontal": 2193,
+				"vertical": ""
+			},
+			"grid_params": {
+				"resolution": 10
+			}
+		},
+		"data_paths": {
+			"catchment_boundary": "tests/test_processor_local_files/data/catchment_boundary.zip",
+			"land": "tests/test_processor_local_files/data/land.zip",
+			"lidars": ["tests/test_processor_local_files/data/lidar.laz"],
+			"reference_dems": ["tests/test_processor_local_files/data/reference_dem.nc"],
+			"bathymetry_contours": ["tests/test_processor_local_files/data/bathymetry.zip"],
+			"temp_raster": "tests/test_processor_local_files/data/temp_dense_dem.tif",
+			"result_dem": "tests/test_processor_local_files/data/test_dem.nc",
+			"benchmark_dem": "tests/test_processor_local_files/data/benchmark_dem.nc"
+		},
+		"general": {
+			"set_dem_shoreline": "True"
+		}
+	}
 }

--- a/tests/test_processor_local_files/instruction.json
+++ b/tests/test_processor_local_files/instruction.json
@@ -1,6 +1,9 @@
 {"instructions": 
   {
-    "projection": 2193,
+    "crs": {
+		"horizontal": 2193,
+		"vertical": ""
+	},
 	"grid_params": {
       "resolution": 10
     },

--- a/tests/test_processor_local_files/test_processor_local_files.py
+++ b/tests/test_processor_local_files/test_processor_local_files.py
@@ -57,7 +57,7 @@ class ProcessorLocalFilesTest(unittest.TestCase):
         y1 = 750
         catchment = shapely.geometry.Polygon([(x0, y0), (x1, y0), (x1, y1), (x0, y1)])
         catchment = geopandas.GeoSeries([catchment])
-        catchment = catchment.set_crs(cls.instructions['instructions']['projection'])
+        catchment = catchment.set_crs(cls.instructions['instructions']['crs']['horizontal'])
         catchment.to_file(catchment_dir)
         shutil.make_archive(base_name=catchment_dir, format='zip', root_dir=catchment_dir)
         shutil.rmtree(catchment_dir)
@@ -70,7 +70,7 @@ class ProcessorLocalFilesTest(unittest.TestCase):
         y1 = 1000
         land = shapely.geometry.Polygon([(x0, y0), (x1, y0), (x1, y1), (x0, y1)])
         land = geopandas.GeoSeries([land])
-        land = land.set_crs(cls.instructions['instructions']['projection'])
+        land = land.set_crs(cls.instructions['instructions']['crs']['horizontal'])
         land.to_file(land_dir)
         shutil.make_archive(base_name=land_dir, format='zip', root_dir=land_dir)
         shutil.rmtree(land_dir)
@@ -86,7 +86,7 @@ class ProcessorLocalFilesTest(unittest.TestCase):
         contour_1 = shapely.geometry.LineString([(x0, y1, -y1/10), (x1, y1, -y1/10)])
         contour_2 = shapely.geometry.LineString([(x0, y2, -y2/10), (x1, y2, -y2/10)])
         contours = geopandas.GeoSeries([contour_0, contour_1, contour_2])
-        contours = contours.set_crs(cls.instructions['instructions']['projection'])
+        contours = contours.set_crs(cls.instructions['instructions']['crs']['horizontal'])
         contours.to_file(bathymetry_dir)
         shutil.make_archive(base_name=bathymetry_dir, format='zip', root_dir=bathymetry_dir)
         shutil.rmtree(bathymetry_dir)
@@ -101,7 +101,7 @@ class ProcessorLocalFilesTest(unittest.TestCase):
             (numpy.abs(grid_dem_x[grid_dem_y > 0] - 750) / 500 + 0.1) / 1.1
         dem = xarray.DataArray(grid_dem_z, coords={'x': grid_dem_x[0], 'y': grid_dem_y[:, 0]}, dims=['y', 'x'],
                                attrs={'scale_factor': 1.0, 'add_offset': 0.0})
-        dem.rio.set_crs(cls.instructions['instructions']['projection'])
+        dem.rio.set_crs(cls.instructions['instructions']['crs']['horizontal'])
         dem.to_netcdf(dem_file)
 
         # create LiDAR
@@ -119,8 +119,9 @@ class ProcessorLocalFilesTest(unittest.TestCase):
         lidar_array['Z'] = grid_lidar_z.flatten()
 
         pdal_pipeline_instructions = [
-            {"type":  "writers.las", "a_srs": "EPSG:" + str(cls.instructions['instructions']['projection']), "filename":
-             str(lidar_file),
+            {"type":  "writers.las",
+             "a_srs": "EPSG:" + str(cls.instructions['instructions']['crs']['horizontal']),
+             "filename": str(lidar_file),
              "compression": "laszip"}
         ]
 

--- a/tests/test_processor_local_files/test_processor_local_files.py
+++ b/tests/test_processor_local_files/test_processor_local_files.py
@@ -57,7 +57,7 @@ class ProcessorLocalFilesTest(unittest.TestCase):
         y1 = 750
         catchment = shapely.geometry.Polygon([(x0, y0), (x1, y0), (x1, y1), (x0, y1)])
         catchment = geopandas.GeoSeries([catchment])
-        catchment = catchment.set_crs(cls.instructions['instructions']['crs']['horizontal'])
+        catchment = catchment.set_crs(cls.instructions['instructions']['output']['crs']['horizontal'])
         catchment.to_file(catchment_dir)
         shutil.make_archive(base_name=catchment_dir, format='zip', root_dir=catchment_dir)
         shutil.rmtree(catchment_dir)
@@ -70,7 +70,7 @@ class ProcessorLocalFilesTest(unittest.TestCase):
         y1 = 1000
         land = shapely.geometry.Polygon([(x0, y0), (x1, y0), (x1, y1), (x0, y1)])
         land = geopandas.GeoSeries([land])
-        land = land.set_crs(cls.instructions['instructions']['crs']['horizontal'])
+        land = land.set_crs(cls.instructions['instructions']['output']['crs']['horizontal'])
         land.to_file(land_dir)
         shutil.make_archive(base_name=land_dir, format='zip', root_dir=land_dir)
         shutil.rmtree(land_dir)
@@ -86,7 +86,7 @@ class ProcessorLocalFilesTest(unittest.TestCase):
         contour_1 = shapely.geometry.LineString([(x0, y1, -y1/10), (x1, y1, -y1/10)])
         contour_2 = shapely.geometry.LineString([(x0, y2, -y2/10), (x1, y2, -y2/10)])
         contours = geopandas.GeoSeries([contour_0, contour_1, contour_2])
-        contours = contours.set_crs(cls.instructions['instructions']['crs']['horizontal'])
+        contours = contours.set_crs(cls.instructions['instructions']['output']['crs']['horizontal'])
         contours.to_file(bathymetry_dir)
         shutil.make_archive(base_name=bathymetry_dir, format='zip', root_dir=bathymetry_dir)
         shutil.rmtree(bathymetry_dir)
@@ -101,7 +101,7 @@ class ProcessorLocalFilesTest(unittest.TestCase):
             (numpy.abs(grid_dem_x[grid_dem_y > 0] - 750) / 500 + 0.1) / 1.1
         dem = xarray.DataArray(grid_dem_z, coords={'x': grid_dem_x[0], 'y': grid_dem_y[:, 0]}, dims=['y', 'x'],
                                attrs={'scale_factor': 1.0, 'add_offset': 0.0})
-        dem.rio.set_crs(cls.instructions['instructions']['crs']['horizontal'])
+        dem.rio.set_crs(cls.instructions['instructions']['output']['crs']['horizontal'])
         dem.to_netcdf(dem_file)
 
         # create LiDAR
@@ -120,7 +120,7 @@ class ProcessorLocalFilesTest(unittest.TestCase):
 
         pdal_pipeline_instructions = [
             {"type":  "writers.las",
-             "a_srs": "EPSG:" + str(cls.instructions['instructions']['crs']['horizontal']),
+             "a_srs": "EPSG:" + str(cls.instructions['instructions']['output']['crs']['horizontal']),
              "filename": str(lidar_file),
              "compression": "laszip"}
         ]

--- a/tests/test_processor_local_files/test_processor_local_files.py
+++ b/tests/test_processor_local_files/test_processor_local_files.py
@@ -120,7 +120,8 @@ class ProcessorLocalFilesTest(unittest.TestCase):
 
         pdal_pipeline_instructions = [
             {"type":  "writers.las",
-             "a_srs": "EPSG:" + str(cls.instructions['instructions']['output']['crs']['horizontal']),
+             "a_srs": f"EPSG:{cls.instructions['instructions']['output']['crs']['horizontal']}+" +
+             f"{cls.instructions['instructions']['output']['crs']['vertical']}",
              "filename": str(lidar_file),
              "compression": "laszip"}
         ]

--- a/tests/test_processor_remote_all_westport/data/benchmark_dem.nc
+++ b/tests/test_processor_remote_all_westport/data/benchmark_dem.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7485111245eb539b9e50629bc0980429e7a18ee4c691f3298cd3315c55433eaa
+oid sha256:ed508fec989003ce8d2ba0cea855d9e4130916b4ce6dafdf15a5e624d6f60810
 size 186952

--- a/tests/test_processor_remote_all_westport/instruction.json
+++ b/tests/test_processor_remote_all_westport/instruction.json
@@ -7,7 +7,7 @@
     "data_paths": {
 		"local_cache": "tests/test_processor_remote_all_westport/data",
 		"benchmark_dem": "tests/test_processor_remote_all_westport/data/benchmark_dem.nc",
-		"result_dem": "tests/test_processor_remote_all_westport/data/benchmark_dem.nc",
+		"result_dem": "tests/test_processor_remote_all_westport/data/test_dem.nc",
 		"catchment_boundary": "tests/test_processor_remote_all_westport/data/catchment.zip"
     },
 	"apis": {

--- a/tests/test_processor_remote_all_westport/instruction.json
+++ b/tests/test_processor_remote_all_westport/instruction.json
@@ -1,30 +1,30 @@
 {"instructions": 
-  {
-    "crs": {
-		"horizontal": 2193,
-		"vertical": 7839
-	},
-	"grid_params": {
-      "resolution": 10
-    },
-    "data_paths": {
-		"local_cache": "tests/test_processor_remote_all_westport/data",
-		"benchmark_dem": "tests/test_processor_remote_all_westport/data/benchmark_dem.nc",
-		"result_dem": "tests/test_processor_remote_all_westport/data/test_dem.nc",
-		"catchment_boundary": "tests/test_processor_remote_all_westport/data/catchment.zip"
-    },
-	"apis": {
-		"open_topography": "True",
-		"linz": {
-			"land": {
-				"layers": [51153],
-				"type": "GEOMETRY"
+	{
+		"output": {
+			"crs": {
+				"horizontal": 2193,
+				"vertical": 7839
 			},
-			"bathymetry_contours": {
-				"layers": [50448],
-				"type": "shape"
+			"grid_params": {
+				"resolution": 10
+			}
+		},
+		"data_paths": {
+			"local_cache": "tests/test_processor_remote_all_westport/data",
+			"benchmark_dem": "tests/test_processor_remote_all_westport/data/benchmark_dem.nc",
+			"result_dem": "tests/test_processor_remote_all_westport/data/test_dem.nc",
+			"catchment_boundary": "tests/test_processor_remote_all_westport/data/catchment.zip"
+		},
+		"apis": {
+			"open_topography": "True",
+			"linz": {
+				"land": {
+					"layers": [51153]
+				},
+				"bathymetry_contours": {
+					"layers": [50448]
+				}
 			}
 		}
 	}
-  }
 }

--- a/tests/test_processor_remote_all_westport/instruction.json
+++ b/tests/test_processor_remote_all_westport/instruction.json
@@ -1,6 +1,9 @@
 {"instructions": 
   {
-    "projection": 2193,
+    "crs": {
+		"horizontal": 2193,
+		"vertical": 7839
+	},
 	"grid_params": {
       "resolution": 10
     },

--- a/tests/test_processor_remote_all_westport/test_processor_remote_all_westport.py
+++ b/tests/test_processor_remote_all_westport/test_processor_remote_all_westport.py
@@ -75,7 +75,7 @@ class ProcessorRemoteAllWestportTest(unittest.TestCase):
         catchment = shapely.geometry.Polygon([(x0, y0), (x0, y3), (x2, y3), (x2, y2),
                                               (x1, y2), (x1, y1), (x2, y1), (x2, y0)])
         catchment = geopandas.GeoSeries([catchment])
-        catchment = catchment.set_crs(cls.instructions['instructions']['projection'])
+        catchment = catchment.set_crs(cls.instructions['instructions']['crs']['horizontal'])
 
         # save faked catchment boundary - used as land boundary as well
         catchment_dir = cls.cache_dir / "catchment"

--- a/tests/test_processor_remote_all_westport/test_processor_remote_all_westport.py
+++ b/tests/test_processor_remote_all_westport/test_processor_remote_all_westport.py
@@ -75,7 +75,7 @@ class ProcessorRemoteAllWestportTest(unittest.TestCase):
         catchment = shapely.geometry.Polygon([(x0, y0), (x0, y3), (x2, y3), (x2, y2),
                                               (x1, y2), (x1, y1), (x2, y1), (x2, y0)])
         catchment = geopandas.GeoSeries([catchment])
-        catchment = catchment.set_crs(cls.instructions['instructions']['crs']['horizontal'])
+        catchment = catchment.set_crs(cls.instructions['instructions']['output']['crs']['horizontal'])
 
         # save faked catchment boundary - used as land boundary as well
         catchment_dir = cls.cache_dir / "catchment"

--- a/tests/test_processor_remote_tiles_wellington/instruction.json
+++ b/tests/test_processor_remote_tiles_wellington/instruction.json
@@ -1,25 +1,34 @@
 {"instructions": 
-  {
-    "crs": {
-		"horizontal": 2193,
-		"vertical": ""
-	},
-	"grid_params": {
-      "resolution": 10
-    },
-    "data_paths": {
-      "local_cache": "tests/test_processor_remote_tiles_wellington/data",
-	  "catchment_boundary": "tests/test_processor_remote_tiles_wellington/data/catchment.zip",
-	  "land": "tests/test_processor_remote_tiles_wellington/data/catchment.zip",
-	  "temp_raster": "tests/test_processor_remote_tiles_wellington/data/temp_dense_dem.tif",
-	  "result_dem": "tests/test_processor_remote_tiles_wellington/data/test_dem.nc",
-	  "benchmark_dem": "tests/test_processor_remote_tiles_wellington/data/benchmark_dem.nc"
-    },
-	"apis": {
-		"open_topography": "True"
-	},
-    "general": {
-      "set_dem_shoreline": "True"
-    }
-  }
+	{
+		"output": {
+			"crs": {
+				"horizontal": 2193,
+				"vertical": ""
+			},
+			"grid_params": {
+				"resolution": 10
+			}
+		},
+		"data_paths": {
+		  "local_cache": "tests/test_processor_remote_tiles_wellington/data",
+		  "catchment_boundary": "tests/test_processor_remote_tiles_wellington/data/catchment.zip",
+		  "land": "tests/test_processor_remote_tiles_wellington/data/catchment.zip",
+		  "temp_raster": "tests/test_processor_remote_tiles_wellington/data/temp_dense_dem.tif",
+		  "result_dem": "tests/test_processor_remote_tiles_wellington/data/test_dem.nc",
+		  "benchmark_dem": "tests/test_processor_remote_tiles_wellington/data/benchmark_dem.nc"
+		},
+		"apis": {
+			"open_topography": {
+				"Wellington_2013": {
+					"crs": {
+						"horizontal": 2193,
+						"vertical": 7839
+					}
+				}
+			}
+		},
+		"general": {
+		  "set_dem_shoreline": "True"
+		}
+	}
 }

--- a/tests/test_processor_remote_tiles_wellington/instruction.json
+++ b/tests/test_processor_remote_tiles_wellington/instruction.json
@@ -3,7 +3,7 @@
 		"output": {
 			"crs": {
 				"horizontal": 2193,
-				"vertical": ""
+				"vertical": 7839
 			},
 			"grid_params": {
 				"resolution": 10

--- a/tests/test_processor_remote_tiles_wellington/instruction.json
+++ b/tests/test_processor_remote_tiles_wellington/instruction.json
@@ -1,6 +1,9 @@
 {"instructions": 
   {
-    "projection": 2193,
+    "crs": {
+		"horizontal": 2193,
+		"vertical": ""
+	},
 	"grid_params": {
       "resolution": 10
     },

--- a/tests/test_processor_remote_tiles_wellington/test_processor_remote_tiles_wellington.py
+++ b/tests/test_processor_remote_tiles_wellington/test_processor_remote_tiles_wellington.py
@@ -62,7 +62,7 @@ class ProcessorRemoteTilesWellingtonTest(unittest.TestCase):
         y1 = 5471304
         catchment = shapely.geometry.Polygon([(x0, y0), (x1, y0), (x1, y1), (x0, y1)])
         catchment = geopandas.GeoSeries([catchment])
-        catchment = catchment.set_crs(cls.instructions['instructions']['crs']['horizontal'])
+        catchment = catchment.set_crs(cls.instructions['instructions']['output']['crs']['horizontal'])
 
         # save faked catchment boundary - used as land boundary as well
         catchment_dir = cls.cache_dir / "catchment"

--- a/tests/test_processor_remote_tiles_wellington/test_processor_remote_tiles_wellington.py
+++ b/tests/test_processor_remote_tiles_wellington/test_processor_remote_tiles_wellington.py
@@ -62,7 +62,7 @@ class ProcessorRemoteTilesWellingtonTest(unittest.TestCase):
         y1 = 5471304
         catchment = shapely.geometry.Polygon([(x0, y0), (x1, y0), (x1, y1), (x0, y1)])
         catchment = geopandas.GeoSeries([catchment])
-        catchment = catchment.set_crs(cls.instructions['instructions']['projection'])
+        catchment = catchment.set_crs(cls.instructions['instructions']['crs']['horizontal'])
 
         # save faked catchment boundary - used as land boundary as well
         catchment_dir = cls.cache_dir / "catchment"

--- a/tests/test_processor_remote_tiles_westport/data/benchmark_dem.nc
+++ b/tests/test_processor_remote_tiles_westport/data/benchmark_dem.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7485111245eb539b9e50629bc0980429e7a18ee4c691f3298cd3315c55433eaa
+oid sha256:ed508fec989003ce8d2ba0cea855d9e4130916b4ce6dafdf15a5e624d6f60810
 size 186952

--- a/tests/test_processor_remote_tiles_westport/instruction.json
+++ b/tests/test_processor_remote_tiles_westport/instruction.json
@@ -1,6 +1,9 @@
 {"instructions": 
   {
-    "projection": 2193,
+    "crs": {
+		"horizontal": 2193,
+		"vertical": 7839
+	},
 	"grid_params": {
       "resolution": 10
     },

--- a/tests/test_processor_remote_tiles_westport/instruction.json
+++ b/tests/test_processor_remote_tiles_westport/instruction.json
@@ -1,25 +1,27 @@
 {"instructions": 
-  {
-    "crs": {
-		"horizontal": 2193,
-		"vertical": 7839
-	},
-	"grid_params": {
-      "resolution": 10
-    },
-	"data_paths": {
-      "local_cache": "tests/test_processor_remote_tiles_westport/data",
-	  "catchment_boundary": "tests/test_processor_remote_tiles_westport/data/catchment.zip",
-	  "land": "tests/test_processor_remote_tiles_westport/data/catchment.zip",
-	  "temp_raster": "tests/test_processor_remote_tiles_westport/data/temp_dense_dem.tif",
-	  "result_dem": "tests/test_processor_remote_tiles_westport/data/test_dem.nc",
-	  "benchmark_dem": "tests/test_processor_remote_tiles_westport/data/benchmark_dem.nc"
-    },
-	"apis": {
-		"open_topography": "True"
-	},
-	"general": {
-      "set_dem_shoreline": "True"
-    }
-  }
+	{
+		"output": {
+			"crs": {
+				"horizontal": 2193,
+				"vertical": 7839
+			},
+			"grid_params": {
+				"resolution": 10
+			}
+		},
+		"data_paths": {
+			"local_cache": "tests/test_processor_remote_tiles_westport/data",
+			"catchment_boundary": "tests/test_processor_remote_tiles_westport/data/catchment.zip",
+			"land": "tests/test_processor_remote_tiles_westport/data/catchment.zip",
+			"temp_raster": "tests/test_processor_remote_tiles_westport/data/temp_dense_dem.tif",
+			"result_dem": "tests/test_processor_remote_tiles_westport/data/test_dem.nc",
+			"benchmark_dem": "tests/test_processor_remote_tiles_westport/data/benchmark_dem.nc"
+		},
+		"apis": {
+			"open_topography": "True"
+		},
+		"general": {
+			"set_dem_shoreline": "True"
+		}
+	}
 }

--- a/tests/test_processor_remote_tiles_westport/test_processor_remote_tiles_westport.py
+++ b/tests/test_processor_remote_tiles_westport/test_processor_remote_tiles_westport.py
@@ -67,7 +67,7 @@ class ProcessorRemoteTilesWestportTest(unittest.TestCase):
         catchment = shapely.geometry.Polygon([(x0, y0), (x0, y3), (x2, y3), (x2, y2),
                                               (x1, y2), (x1, y1), (x2, y1), (x2, y0)])
         catchment = geopandas.GeoSeries([catchment])
-        catchment = catchment.set_crs(cls.instructions['instructions']['crs']['horizontal'])
+        catchment = catchment.set_crs(cls.instructions['instructions']['output']['crs']['horizontal'])
 
         # save faked catchment boundary - used as land boundary as well
         catchment_dir = cls.cache_dir / "catchment"

--- a/tests/test_processor_remote_tiles_westport/test_processor_remote_tiles_westport.py
+++ b/tests/test_processor_remote_tiles_westport/test_processor_remote_tiles_westport.py
@@ -67,7 +67,7 @@ class ProcessorRemoteTilesWestportTest(unittest.TestCase):
         catchment = shapely.geometry.Polygon([(x0, y0), (x0, y3), (x2, y3), (x2, y2),
                                               (x1, y2), (x1, y1), (x2, y1), (x2, y0)])
         catchment = geopandas.GeoSeries([catchment])
-        catchment = catchment.set_crs(cls.instructions['instructions']['projection'])
+        catchment = catchment.set_crs(cls.instructions['instructions']['crs']['horizontal'])
 
         # save faked catchment boundary - used as land boundary as well
         catchment_dir = cls.cache_dir / "catchment"


### PR DESCRIPTION
No consideration has been given to vertical and horizontal datums for input data and even the output DEM. Begin adding support for vertical datums by first adding it for LiDAR data. _There are instances where LiDAR data has a vertical datum, but it has not been encoded in the LAZ file. As a result, we will need to support specifying the datum of the DEM we are generating, as well as optionally specifying the datum of the data we are reading - in the case it may not be specified._

- [X] Add an the concept of an overall vertical and horizontal datum (i.e. defines the datum of the output DEM)
- [X] Add an optional vertical and/or horizontal datum for LiDAR datasets to apply to all LiDAR files read in for that dataset
- [x] Apply horizontal and vertical datums re-projections to each LiDAR dataset
  - [x] If a LiDAR dataset horizontal/vertical datum is specified - then define as IN_SRS to override the CRS in the LAZ files
- [X] Update the tests accordingly
- [x] Update the documentation

Things that will be done in a later issue/PR include:
* Add a test using a local datum
* Add support for vertical and horizontal datum's in vectors