### PR TITLE
Update geofabrics to work with the latest version of geoapis

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,3 +8,4 @@ DESCRIPTION OF PR:
  - [ ] Update documentation
    - [ ] Doc strings
    - [ ] Wiki 
+  - [ ] Update package version (if needed) 

--- a/src/geofabrics/__init__.py
+++ b/src/geofabrics/__init__.py
@@ -5,4 +5,4 @@ Created on Thu Jul  1 09:57:30 2021
 @author: pearsonra
 """
 
-__version__ = "0.7.1"
+__version__ = "0.7.2"

--- a/src/geofabrics/processor.py
+++ b/src/geofabrics/processor.py
@@ -239,8 +239,8 @@ class BaseProcessor(abc.ABC):
                 "'file_paths' in the instruction file if you are going to use an API - like 'open_topography'"
 
             # download from OpenTopography - then get the local file path
-            self.lidar_fetcher = geoapis.lidar.OpenTopography(self.catchment_geometry.catchment,
-                                                              self.get_instruction_path('local_cache'),
+            self.lidar_fetcher = geoapis.lidar.OpenTopography(cache_path=self.get_instruction_path('local_cache'),
+                                                              search_polygon=self.catchment_geometry.catchment,
                                                               verbose=self.verbose)
             self.lidar_fetcher.run()
             dataset_prefix = self.lidar_fetcher.dataset_prefixes[lidar_dataset_index]


### PR DESCRIPTION
Update geofabrics to work with the latest version of geoapis (it includes a change to the lidar.OpenTopography interface):
 - [X] Make code change
 - [x] Update tests 
   - [X] Update / create new tests
   - [X] Ensure these tests have the expected behavour
   - [x] Test locally and ensure tests are passing
 - [x] Ensure tests passing on GH Actions
 - [X] Update documentation
   - [X] Doc strings
   - [X] Wiki 
