### PR TITLE
Added the option of not interpolating missing values in the raster. C…

### DIFF
--- a/src/geofabrics/dem.py
+++ b/src/geofabrics/dem.py
@@ -131,7 +131,8 @@ class DenseDem(abc.ABC):
     CACHE_SIZE = 10000  # The max number of points to create the offshore RBF and to evaluate in the RBF at one time
 
     def __init__(self, catchment_geometry: geometry.CatchmentGeometry, extents: geopandas.GeoDataFrame,
-                 dense_dem: xarray.core.dataarray.DataArray, verbose: bool = True):
+                 dense_dem: xarray.core.dataarray.DataArray, verbose: bool,
+                 interpolate_missing_values: bool):
         """ Setup base DEM to add future tiles too """
 
         self.catchment_geometry = catchment_geometry
@@ -139,6 +140,7 @@ class DenseDem(abc.ABC):
         self._extents = extents
 
         self.verbose = verbose
+        self.interpolate_missing_values = interpolate_missing_values
 
         self._offshore_dem = None
 
@@ -166,7 +168,8 @@ class DenseDem(abc.ABC):
 
         # Ensure valid name and increasing dimension indexing for the dem
         self._dem = self._dem.rename(self.DENSE_BINNING)
-        self._dem = self._dem.rio.interpolate_na()
+        if self.interpolate_missing_values:
+            self._dem = self._dem.rio.interpolate_na(method='nearest')  # other methods are 'linear' and 'cubic'
         self._dem = self._dem.rio.clip(self.catchment_geometry.catchment.geometry)
         self._dem = self._ensure_positive_indexing(self._dem)  # Some programs require positively increasing indices
         return self._dem
@@ -274,7 +277,7 @@ class DenseDemFromFiles(DenseDem):
 
     def __init__(self, catchment_geometry: geometry.CatchmentGeometry,
                  dense_dem_path: typing.Union[str, pathlib.Path], extents_path: typing.Union[str, pathlib.Path],
-                 verbose: bool = True):
+                 verbose: bool = True, interpolate_missing_values: bool = True):
         """ Load in the extents and dense DEM. Ensure the dense DEM is clipped within the extents """
 
         extents = geopandas.read_file(pathlib.Path(extents_path))
@@ -292,7 +295,8 @@ class DenseDemFromFiles(DenseDem):
 
         # Setup the DenseDem class
         super(DenseDemFromFiles, self).__init__(catchment_geometry=catchment_geometry, dense_dem=dense_dem,
-                                                extents=extents, verbose=verbose)
+                                                extents=extents, verbose=verbose,
+                                                interpolate_missing_values=interpolate_missing_values)
 
 
 class DenseDemFromTiles(DenseDem):
@@ -307,7 +311,7 @@ class DenseDemFromTiles(DenseDem):
     """
 
     def __init__(self, catchment_geometry: geometry.CatchmentGeometry, drop_offshore_lidar: bool = True,
-                 area_to_drop: float = None, verbose: bool = True):
+                 area_to_drop: float = None, verbose: bool = True, interpolate_missing_values: bool = True):
         """ Setup base DEM to add future tiles too """
 
         self.area_to_drop = area_to_drop
@@ -318,7 +322,8 @@ class DenseDemFromTiles(DenseDem):
         empty_dem = self._set_up(catchment_geometry)
 
         super(DenseDemFromTiles, self).__init__(catchment_geometry=catchment_geometry, dense_dem=empty_dem,
-                                                extents=None, verbose=verbose)
+                                                extents=None, verbose=verbose,
+                                                interpolate_missing_values=interpolate_missing_values)
 
     def _set_up(self, catchment_geometry):
         """ Create the empty dense DEM to fill and define the raster size and origin """

--- a/src/geofabrics/processor.py
+++ b/src/geofabrics/processor.py
@@ -93,7 +93,8 @@ class BaseProcessor(abc.ABC):
         the instruction file. Raise an error if the key is not in the instructions and there is no default value. """
 
         defaults = {'filter_lidar_holes_area': None, 'verbose': True, 'set_dem_shoreline': True,
-                    'bathymetry_contours_z_label': None, 'drop_offshore_lidar': True, 'keep_only_ground_lidar': True}
+                    'bathymetry_contours_z_label': None, 'drop_offshore_lidar': True, 'keep_only_ground_lidar': True,
+                    'interpolate_missing_values': True}
 
         assert key in defaults or key in self.instructions['instructions']['general'], f"The key: {key} is missing " \
             + "from the general instructions, and does not have a default value"
@@ -325,10 +326,11 @@ class DemGenerator(BaseProcessor):
         lidar_dataset_info = self.get_lidar_file_list('open_topography')
 
         # setup dense DEM and catchment LiDAR objects
-        self.dense_dem = dem.DenseDemFromTiles(catchment_geometry=self.catchment_geometry,
-                                               area_to_drop=self.get_instruction_general('filter_lidar_holes_area'),
-                                               drop_offshore_lidar=self.get_instruction_general('drop_offshore_lidar'),
-                                               verbose=self.verbose)
+        self.dense_dem = dem.DenseDemFromTiles(
+            catchment_geometry=self.catchment_geometry,
+            area_to_drop=self.get_instruction_general('filter_lidar_holes_area'),
+            drop_offshore_lidar=self.get_instruction_general('drop_offshore_lidar'), verbose=self.verbose,
+            interpolate_missing_values=self.get_instruction_general('interpolate_missing_values'))
         self.catchment_lidar = lidar.CatchmentLidar(
             self.catchment_geometry, source_crs=lidar_dataset_info['crs'],
             drop_offshore_lidar=self.get_instruction_general('drop_offshore_lidar'),


### PR DESCRIPTION
Expose the option of interpolating any missing values in the final raster using nearest neighbour. Currently this is the default behaviour. If `interpolate_missing_values` is set to `False` in the instruction file then no interpolation will be performed. 

DESCRIPTION OF PR:
 - [X] Make code change
 - [ ] Update tests 
   - [ ] Update / create new tests
   - [ ] Ensure these tests have the expected behavour
   - [ ] Test locally and ensure tests are passing
 - [ ] Ensure tests passing on GH Actions
 - [ ] Update documentation
   - [ ] Doc strings
   - [ ] Wiki 
  - [ ] Update package version (if needed) 
