### PR TITLE
Processing DEM in chunks using Dask

### DIFF
--- a/.github/workflows/linux-test.yml
+++ b/.github/workflows/linux-test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8]
+        python-version: [3.9]
 
     steps:
 

--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,9 @@ local_settings.py
 db.sqlite3
 db.sqlite3-journal
 
+# Dask distributed
+dask-worker-space/
+
 # Flask stuff:
 instance/
 .webassets-cache

--- a/environment_linux.yml
+++ b/environment_linux.yml
@@ -10,6 +10,7 @@ dependencies:
   - geopandas
   - rioxarray
   - pdal
+  - dask
   - python-pdal
   - python-dotenv
   - pytest

--- a/environment_linux.yml
+++ b/environment_linux.yml
@@ -11,6 +11,7 @@ dependencies:
   - rioxarray
   - pdal
   - dask
+  - distributed
   - python-pdal
   - python-dotenv
   - pytest

--- a/environment_windows.yml
+++ b/environment_windows.yml
@@ -15,6 +15,7 @@ dependencies:
   - python-dotenv
   - matplotlib
   - dask
+  - distributed
   - ipykernel
   - ipython
   - ipython_genutils

--- a/environment_windows.yml
+++ b/environment_windows.yml
@@ -14,6 +14,7 @@ dependencies:
   - python-pdal
   - python-dotenv
   - matplotlib
+  - dask
   - ipykernel
   - ipython
   - ipython_genutils

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,8 @@ setuptools.setup(
                       'geopandas>=0.10',
                       'shapely>=1.7',
                       'scipy>=1.6',
+                      'dask>=2021.9',
+                      'distributed>=2021.9',
                       'python-dotenv>=0.19'],
     extras_require={
         'dev': ['check-manifest'],

--- a/src/geofabrics/__init__.py
+++ b/src/geofabrics/__init__.py
@@ -5,4 +5,4 @@ Created on Thu Jul  1 09:57:30 2021
 @author: pearsonra
 """
 
-__version__ = "0.7.5"
+__version__ = "0.7.6"

--- a/src/geofabrics/dem.py
+++ b/src/geofabrics/dem.py
@@ -701,24 +701,6 @@ def rasterise_with_idw(point_cloud: numpy.ndarray, xy_out, idw_radius: float, id
     return z_out
 
 
-@dask.delayed
-def delayed_load_tiles_in_chunk(dim_x: numpy.ndarray, dim_y: numpy.ndarray, tile_index_extents: geopandas.GeoDataFrame,
-                                tile_index_name_column: str, lidar_files: typing.List[typing.Union[str, pathlib.Path]],
-                                source_crs: dict, chunk_region_to_tile: geopandas.GeoDataFrame,
-                                catchment_geometry: geometry.CatchmentGeometry, verbose: bool):
-    """ Call load_tiles_in_chunk function but with delayed calling supported. """
-
-    return load_tiles_in_chunk(dim_x=dim_x,
-                               dim_y=dim_y,
-                               tile_index_extents=tile_index_extents,
-                               tile_index_name_column=tile_index_name_column,
-                               lidar_files=lidar_files,
-                               source_crs=source_crs,
-                               chunk_region_to_tile=chunk_region_to_tile,
-                               catchment_geometry=catchment_geometry,
-                               verbose=verbose)
-
-
 def load_tiles_in_chunk(dim_x: numpy.ndarray, dim_y: numpy.ndarray, tile_index_extents: geopandas.GeoDataFrame,
                         tile_index_name_column: str, lidar_files: typing.List[typing.Union[str, pathlib.Path]],
                         source_crs: dict, chunk_region_to_tile: geopandas.GeoDataFrame,
@@ -756,24 +738,6 @@ def load_tiles_in_chunk(dim_x: numpy.ndarray, dim_y: numpy.ndarray, tile_index_e
     return lidar_points
 
 
-@dask.delayed
-def delayed_rasterise_chunk(dim_x: numpy.ndarray, dim_y: numpy.ndarray, tile_points: numpy.ndarray, raster_type,
-                            keep_only_ground_lidar: bool, ground_code: int, idw_radius: float, idw_power: int,
-                            verbose: bool, chunk_region_to_raster: geopandas.GeoDataFrame):
-    """ Call rasterise_chunk function but with delayed calling supported. """
-
-    return rasterise_chunk(dim_x=dim_x,
-                           dim_y=dim_y,
-                           tile_points=tile_points,
-                           raster_type=raster_type,
-                           keep_only_ground_lidar=keep_only_ground_lidar,
-                           ground_code=ground_code,
-                           idw_radius=idw_radius,
-                           idw_power=idw_power,
-                           verbose=verbose,
-                           chunk_region_to_raster=chunk_region_to_raster)
-
-
 def rasterise_chunk(dim_x: numpy.ndarray, dim_y: numpy.ndarray, tile_points: numpy.ndarray, raster_type,
                     keep_only_ground_lidar: bool, ground_code: int, idw_radius: float, idw_power: int, verbose: bool,
                     chunk_region_to_raster: geopandas.GeoDataFrame):
@@ -807,11 +771,18 @@ def rasterise_chunk(dim_x: numpy.ndarray, dim_y: numpy.ndarray, tile_points: num
         [chunk_region_to_raster.iloc[0].geometry.contains(shapely.geometry.Point(point)) for point in xy_out])
 
     # Perform IDW over the dense DEM within the extents of this point cloud tile
-    z_idw = rasterise_with_idw(point_cloud=tile_points, xy_out=xy_out[in_region_mask],
-                               idw_radius=idw_radius, idw_power=idw_power,
-                               smoothing=0, eps=0, leaf_size=10, raster_type=raster_type)
-    grid_z[in_region_mask.reshape(grid_x.shape)] = z_idw
+    if in_region_mask.sum() > 0:  # but only if any pixels are in the region to rasterise
+        z_idw = rasterise_with_idw(point_cloud=tile_points, xy_out=xy_out[in_region_mask],
+                                   idw_radius=idw_radius, idw_power=idw_power,
+                                   smoothing=0, eps=0, leaf_size=10, raster_type=raster_type)
+        grid_z[in_region_mask.reshape(grid_x.shape)] = z_idw
 
     # TODO - add roughness calculation
 
     return grid_z
+
+
+delayed_rasterise_chunk = dask.delayed(rasterise_chunk)
+
+
+delayed_load_tiles_in_chunk = dask.delayed(load_tiles_in_chunk)

--- a/src/geofabrics/dem.py
+++ b/src/geofabrics/dem.py
@@ -625,7 +625,7 @@ class DenseDemFromTiles(DenseDem):
         chunked_dim_x, chunked_dim_y = self._set_up_chunks(chunk_size)
 
         # Setup Dask cluster and client
-        cluster_kwargs = {'n_workers': 4, 'threads_per_worker': 1, 'processes': True}
+        cluster_kwargs = {'n_workers': 1, 'threads_per_worker': 1, 'processes': True}
         with distributed.LocalCluster(**cluster_kwargs) as cluster, distributed.Client(cluster) as client:
             print(client)
 

--- a/src/geofabrics/dem.py
+++ b/src/geofabrics/dem.py
@@ -385,11 +385,8 @@ class DenseDemFromTiles(DenseDem):
         dense_extents = dense_extents.affine_transform([dense_dem_affine.a, dense_dem_affine.b,
                                                         dense_dem_affine.d, dense_dem_affine.e,
                                                         dense_dem_affine.xoff, dense_dem_affine.yoff])
+        dense_extents = geopandas.GeoDataFrame(geometry=dense_extents)
 
-        # Ensure only the exterior of the region is captured. This will need to revisited if supporting lakes!
-        dense_extents = geopandas.GeoDataFrame({'geometry': [shapely.geometry.Polygon(exterior) for exterior
-                                                             in dense_extents.exterior]},
-                                               crs=self.catchment_geometry.crs['horizontal'])
         return dense_extents
 
     def _tile_index_column_name(self, tile_index_file: typing.Union[str, pathlib.Path] = None):

--- a/src/geofabrics/dem.py
+++ b/src/geofabrics/dem.py
@@ -312,7 +312,6 @@ class DenseDemFromTiles(DenseDem):
     The dense DEM is made up of tiles created from dense point data - Either LiDAR point clouds, or a reference DEM
 
     DenseDemFromTiles logic can be controlled by the constructor inputs:
-        * area_to_drop - If '> 0' this defines the size of any holes in the LiDAR coverage to ignore.
         * drop_offshore_lidar - If True only keep LiDAR values within the foreshore and land regions defined by
           the catchment_geometry. If False keep all LiDAR values.
         * interpolate_missing_values - If True any missing values at the end of the rasterisation process will be
@@ -324,11 +323,10 @@ class DenseDemFromTiles(DenseDem):
     LAS_GROUND = 2  # As specified in the LAS/LAZ format
 
     def __init__(self, catchment_geometry: geometry.CatchmentGeometry, idw_power: int, idw_radius: float,
-                 drop_offshore_lidar: bool = True, area_to_drop: float = None,
+                 drop_offshore_lidar: bool = True,
                  interpolate_missing_values: bool = True):
         """ Setup base DEM to add future tiles too """
 
-        self.area_to_drop = area_to_drop
         self.drop_offshore_lidar = drop_offshore_lidar
 
         self.raster_type = numpy.float64

--- a/src/geofabrics/dem.py
+++ b/src/geofabrics/dem.py
@@ -741,18 +741,25 @@ def rasterise_chunk(dim_x: numpy.ndarray, dim_y: numpy.ndarray, tile_points: num
     """ Rasterise all points within a chunk. In future we may want to use the region to rasterise to define which
     points to rasterise. """
 
+    # Get the indicies overwhich to perform IDW
+    grid_x, grid_y = numpy.meshgrid(dim_x, dim_y)
+    xy_out = numpy.concatenate([[grid_x.flatten()], [grid_y.flatten()]], axis=0).transpose()
+
+    # If no points return an array of NaN
+    if len(tile_points) == 0:
+        if verbose:
+            print("Warning in DenseDem._rasterise_over_chunk the latest chunk has no data and is being ignored.")
+        return numpy.ones(grid_x.shape) * numpy.nan
+
     # use only ground points for idw ground calculations - note the code works even if for empty input tile_points
     if keep_only_ground_lidar:
         tile_points = tile_points[tile_points['Classification'] == ground_code]
 
+    # Check again - if no points return an array of NaN
     if len(tile_points) == 0:
         if verbose:
             print("Warning in DenseDem._rasterise_over_chunk the latest chunk has no data and is being ignored.")
-        return
-
-    # Get the indicies overwhich to perform IDW
-    grid_x, grid_y = numpy.meshgrid(dim_x, dim_y)
-    xy_out = numpy.concatenate([[grid_x.flatten()], [grid_y.flatten()]], axis=0).transpose()
+        return numpy.ones(grid_x.shape) * numpy.nan
 
     # Perform IDW over the dense DEM within the extents of this point cloud tile
     z_idw = rasterise_with_idw(point_cloud=tile_points, xy_out=xy_out, idw_radius=idw_radius, idw_power=idw_power,

--- a/src/geofabrics/dem.py
+++ b/src/geofabrics/dem.py
@@ -592,6 +592,9 @@ class DenseDemFromTiles(DenseDem):
                                              source_crs=source_crs, keep_only_ground_lidar=keep_only_ground_lidar)
         else:
             assert tile_index_file is not None, "A tile index file is required for multiple tile files added together"
+            assert chunk_size > 0 and chunk_size is not None, "The chunk size should be set when reading in tiled LiDAR " \
+                "files. Ideally it should include as many tiles can easily be read in by on core. You will have to equate" \
+                " The tile extents with chunk size by extents / resolution. "
             self._dense_dem = self._add_tiled_lidar_chunked(lidar_files=lidar_files, tile_index_file=tile_index_file,
                                                             source_crs=source_crs,
                                                             keep_only_ground_lidar=keep_only_ground_lidar,

--- a/src/geofabrics/dem.py
+++ b/src/geofabrics/dem.py
@@ -571,9 +571,9 @@ class DenseDemFromTiles(DenseDem):
 
         # cycle through index chunks - and collect in a delayed array
         delayed_chunked_matrix = []
-        for i, dim_x in enumerate(chunked_dim_x):
+        for i, dim_y in enumerate(chunked_dim_y):
             delayed_chunked_x = []
-            for j, dim_y in enumerate(chunked_dim_y):
+            for j, dim_x in enumerate(chunked_dim_x):
                 if self.verbose:
                     print(f"Rasterising chunk {[i, j]} out of {[len(chunked_dim_x), len(chunked_dim_y)]} chunks")
                 tile_points = self._load_tiles_in_chunk(dim_x=dim_x, dim_y=dim_y, tile_index_extents=tile_index_extents,

--- a/src/geofabrics/dem.py
+++ b/src/geofabrics/dem.py
@@ -163,6 +163,11 @@ class DenseDem(abc.ABC):
         return self._extents
 
     @property
+    def dense_dem(self):
+        """ Return the dense DEM from tiles and any interpolated offshore values """
+        return self._dense_dem
+
+    @property
     def dem(self):
         """ Return the combined DEM from tiles and any interpolated offshore values """
 

--- a/src/geofabrics/dem.py
+++ b/src/geofabrics/dem.py
@@ -765,17 +765,11 @@ def rasterise_chunk(dim_x: numpy.ndarray, dim_y: numpy.ndarray, tile_points: num
             print("Warning in DenseDem._rasterise_over_chunk the latest chunk has no data and is being ignored.")
         return grid_z
 
-    # Create a Boolean mask of only points in the region to raster
-    assert len(chunk_region_to_raster) == 1, "Need to combine the region to rasterise into a single multipolygon"
-    in_region_mask = numpy.array(
-        [chunk_region_to_raster.iloc[0].geometry.contains(shapely.geometry.Point(point)) for point in xy_out])
-
     # Perform IDW over the dense DEM within the extents of this point cloud tile
-    if in_region_mask.sum() > 0:  # but only if any pixels are in the region to rasterise
-        z_idw = rasterise_with_idw(point_cloud=tile_points, xy_out=xy_out[in_region_mask],
-                                   idw_radius=idw_radius, idw_power=idw_power,
-                                   smoothing=0, eps=0, leaf_size=10, raster_type=raster_type)
-        grid_z[in_region_mask.reshape(grid_x.shape)] = z_idw
+    z_idw = rasterise_with_idw(point_cloud=tile_points, xy_out=xy_out,
+                               idw_radius=idw_radius, idw_power=idw_power,
+                               smoothing=0, eps=0, leaf_size=10, raster_type=raster_type)
+    grid_z = z_idw.reshape(grid_x.shape)
 
     # TODO - add roughness calculation
 

--- a/src/geofabrics/geometry.py
+++ b/src/geofabrics/geometry.py
@@ -148,6 +148,8 @@ class CatchmentGeometry:
                 print("Warning dense extents are `None` so `offshore_without_lidar`" +
                       "is returning `offshore`")
             return self.offshore
+        elif self.offshore.area.sum() == 0:  # There is no offshore region - return an empty dataframe
+            return self.offshore
 
         offshore_with_lidar = geopandas.clip(dense_extents, self.offshore)
         offshore_without_lidar = geopandas.overlay(self.offshore, offshore_with_lidar, how="difference")

--- a/src/geofabrics/geometry.py
+++ b/src/geofabrics/geometry.py
@@ -9,6 +9,7 @@ import shapely
 import numpy
 import pathlib
 import typing
+import logging
 
 
 class CatchmentGeometry:
@@ -31,12 +32,11 @@ class CatchmentGeometry:
     foreshore, etc) can be accessed. """
 
     def __init__(self, catchment_file: typing.Union[str, pathlib.Path], crs: dict, resolution: float,
-                 foreshore_buffer: int = 2, verbose: bool = True):
+                 foreshore_buffer: int = 2):
         self._catchment = geopandas.read_file(catchment_file)
         self.crs = crs
         self.resolution = resolution
         self.foreshore_buffer = foreshore_buffer
-        self.verbose = True
 
         # set catchment CRS
         self._catchment = self._catchment.to_crs(self.crs['horizontal'])
@@ -127,9 +127,8 @@ class CatchmentGeometry:
         self._assert_land_set()
 
         if dense_extents is None:
-            if self.verbose:
-                print("Warning dense extents are `None` so `land_and_foreshore_without_lidar`" +
-                      "is returning `land_and_foreshore`")
+            logging.warning("In CatchmentGeometry dense extents are `None` so `land_and_foreshore_without_lidar`" +
+                            "is returning `land_and_foreshore`")
             return self.land_and_foreshore
 
         # Clip to remove any offshore regions before doing a difference overlay. Drop any sub-pixel polygons.
@@ -147,9 +146,8 @@ class CatchmentGeometry:
         self._assert_land_set()
 
         if dense_extents is None:
-            if self.verbose:
-                print("Warning dense extents are `None` so `offshore_without_lidar`" +
-                      "is returning `offshore`")
+            logging.warning("In CatchmentGeometry dense extents are `None` so `offshore_without_lidar`" +
+                            "is returning `offshore`")
             return self.offshore
         elif self.offshore.area.sum() == 0:  # There is no offshore region - return an empty dataframe
             return self.offshore
@@ -167,9 +165,8 @@ class CatchmentGeometry:
         self._assert_land_set()
 
         if dense_extents is None:
-            if self.verbose:
-                print("Warning dense extents are `None` so `offshore_dense_data_edge`" +
-                      "is returning `None`")
+            logging.warning("In CatchmentGeometry dense extents are `None` so `offshore_dense_data_edge`" +
+                            "is returning `None`")
             return None
 
         # the foreshore and whatever lidar extents are offshore

--- a/src/geofabrics/geometry.py
+++ b/src/geofabrics/geometry.py
@@ -151,7 +151,9 @@ class CatchmentGeometry:
         elif self.offshore.area.sum() == 0:  # There is no offshore region - return an empty dataframe
             return self.offshore
 
-        offshore_with_lidar = geopandas.clip(dense_extents, self.offshore)
+        # Clip to remove any offshore regions before doing a difference overlay. Drop any sub-pixel polygons.
+        offshore_with_lidar = dense_extents.clip(self.offshore, keep_geom_type=True)
+        offshore_with_lidar = offshore_with_lidar[offshore_with_lidar.area > self.resolution * self.resolution]
         offshore_without_lidar = geopandas.overlay(self.offshore, offshore_with_lidar, how="difference")
 
         return offshore_without_lidar

--- a/src/geofabrics/geometry.py
+++ b/src/geofabrics/geometry.py
@@ -20,10 +20,10 @@ class CatchmentGeometry:
     Specifically, this defines polygon regions like 'land', 'foreshore', 'offshore', and ensures all regions are
     defined in the same CRS.
 
-    The land, foreshore and offshore regions are clipped within the catchment, but do not overlap. The land is
-    polygon is defined by a specified polygon which is clipped within the catchment. The foreshore is defined
-    as a 'foreshore_buffer' x 'resolution' outward buffer from the land and within the catchment extents. The offshore
-    region is any remaining region within the catchment region and outside the land and foreshore polygons.
+    The 'land', 'foreshore' and 'offshore' regions are clipped within the 'catchment', but do not overlap. The 'land' is
+    polygon is defined by a specified polygon which is clipped within the 'catchment'. The 'foreshore' is defined
+    as a 'foreshore_buffer' x 'resolution' outward buffer from the 'land' and within the 'catchment' extents. The
+    'offshore' region is any remaining region within the 'catchment' and outside the 'land' and 'foreshore' polygons.
 
     It also supports functions for determining how much of a region is outside an exclusion zone. I.E. is outside
     `lidar_extents` see class method land_and_foreshore_without_lidar for an example.
@@ -69,6 +69,7 @@ class CatchmentGeometry:
             "polygon object - a MultiPolygon is fine"
 
     def _assert_land_set(self):
+        """ Check to make sure the 'land' has been set. """
         assert self._land is not None, "Land has not been set yet. This must be set before anything other than the " + \
             "`catchment` can be returned from a `CatchmentGeometry` object"
 

--- a/src/geofabrics/geometry.py
+++ b/src/geofabrics/geometry.py
@@ -53,13 +53,18 @@ class CatchmentGeometry:
 
         self._land = self._land.to_crs(self.crs['horizontal'])
 
+        # Clip and remove any sub pixel regions
         self._land = self._catchment.clip(self._land, keep_geom_type=True)
+        self._land = self._land[self._land.area > self.resolution * self.resolution]
 
         self._foreshore_and_offshore = self.catchment.overlay(self.land, how='difference')
 
+        # Buffer and clip and remove any sub pixel regions
         self._land_and_foreshore = geopandas.GeoDataFrame(
             {'geometry': self.land.buffer(self.resolution * self.foreshore_buffer)}, crs=self.crs['horizontal'])
         self._land_and_foreshore = self._catchment.clip(self._land_and_foreshore, keep_geom_type=True)
+        self._land_and_foreshore = self._land_and_foreshore[self._land_and_foreshore.area
+                                                            > self.resolution * self.resolution]
 
         self._foreshore = self.land_and_foreshore.overlay(self.land, how='difference')
 

--- a/src/geofabrics/processor.py
+++ b/src/geofabrics/processor.py
@@ -361,7 +361,7 @@ class DemGenerator(BaseProcessor):
                     f"{len(self.get_instruction_path('reference_dems'))} reference_dems specified, but only one supported" \
                     + f" currently. reference_dems: {self.get_instruction_path('reference_dems')}"
 
-                logging.info(f"Incorporting background DEM: {self.get_instruction_path('reference_dems')}")
+                logging.info(f"Incorporating background DEM: {self.get_instruction_path('reference_dems')}")
 
                 # Load in background DEM - cut away within the LiDAR extents
                 self.reference_dem = dem.ReferenceDem(dem_file=self.get_instruction_path('reference_dems')[0],
@@ -384,7 +384,7 @@ class DemGenerator(BaseProcessor):
                 assert len(bathy_contour_dirs) == 1, f"{len(bathy_contour_dirs)} bathymetry_contours's provided. " + \
                     f"Specficially {catchment_dirs}. Support has not yet been added for multiple datasets."
 
-                logging.info(f"Incorporting Bathymetry: {bathy_contour_dirs}")
+                logging.info(f"Incorporating Bathymetry: {bathy_contour_dirs}")
 
                 # Load in bathymetry
                 self.bathy_contours = geometry.BathymetryContours(
@@ -457,7 +457,7 @@ class OffshoreDemGenerator(BaseProcessor):
             assert len(bathy_contour_dirs) == 1, f"{len(bathy_contour_dirs)} bathymetry_contours's provided. " + \
                 f"Specficially {catchment_dirs}. Support has not yet been added for multiple datasets."
 
-            logging.info(f"Incorporting Bathymetry: {bathy_contour_dirs}")
+            logging.info(f"Incorporating Bathymetry: {bathy_contour_dirs}")
 
             # Load in bathymetry
             self.bathy_contours = geometry.BathymetryContours(

--- a/src/geofabrics/processor.py
+++ b/src/geofabrics/processor.py
@@ -353,10 +353,6 @@ class DemGenerator(BaseProcessor):
 
         # save dense DEM results
         self.dense_dem.dense_dem.to_netcdf(self.get_instruction_path('dense_dem'))
-        if self.dense_dem.extents is not None:  # Save ou the extents of the LiDAR - before reference DEM
-            self.dense_dem.extents.to_file(self.get_instruction_path('dense_dem_extents'))
-        else:
-            logging.warning("In processor.DemGenerator - no LiDAR extents exist so no extents file written")
 
         # Load in reference DEM if any significant land/foreshore not covered by LiDAR
         if self.check_instruction_path('reference_dems'):
@@ -379,6 +375,11 @@ class DemGenerator(BaseProcessor):
                 # Add the reference DEM patch where there's no LiDAR to the dense DEM without updting the extents
                 self.dense_dem.add_reference_dem(tile_points=self.reference_dem.points,
                                                  tile_extent=self.reference_dem.extents)
+
+        if self.dense_dem.extents is not None:  # Save ou the extents of the LiDAR - before reference DEM
+            self.dense_dem.extents.to_file(self.get_instruction_path('dense_dem_extents'))
+        else:
+            logging.warning("In processor.DemGenerator - no LiDAR extents exist so no extents file written")
 
         # Load in bathymetry and interpolate offshore if significant offshore is not covered by LiDAR
         if self.check_vector('bathymetry_contours'):

--- a/src/geofabrics/processor.py
+++ b/src/geofabrics/processor.py
@@ -343,13 +343,13 @@ class DemGenerator(BaseProcessor):
             interpolate_missing_values=self.get_instruction_general('interpolate_missing_values'),
             idw_power=idw_power, idw_radius=idw_radius)
 
-        # Load in LiDAR tiles
         # Setup Dask cluster and client
         cluster_kwargs = {'n_workers': self.get_processing_instructions('number_of_cores'),
                           'threads_per_worker': 1,
                           'processes': True}
         with distributed.LocalCluster(**cluster_kwargs) as cluster, distributed.Client(cluster) as client:
             print(client)
+            # Load in LiDAR tiles
             self.dense_dem.add_lidar(lidar_files=lidar_dataset_info['file_paths'], source_crs=lidar_dataset_info['crs'],
                                      drop_offshore_lidar=self.get_instruction_general('drop_offshore_lidar'),
                                      keep_only_ground_lidar=self.get_instruction_general('keep_only_ground_lidar'),

--- a/src/geofabrics/processor.py
+++ b/src/geofabrics/processor.py
@@ -102,6 +102,19 @@ class BaseProcessor(abc.ABC):
         else:
             return defaults[key]
 
+    def get_processing_instructions(self, key: str):
+        """ Return the general instruction from the instruction file or return the default value if not specified in
+        the instruction file. Raise an error if the key is not in the instructions and there is no default value. """
+
+        defaults = {'number_of_cores': 1, "chunk_size": None}
+
+        assert key in defaults or key in self.instructions['instructions']['processing'], f"The key: {key} is missing " \
+            + "from the general instructions, and does not have a default value"
+        if 'processing' in self.instructions['instructions'] and key in self.instructions['instructions']['processing']:
+            return self.instructions['instructions']['processing'][key]
+        else:
+            return defaults[key]
+
     def check_apis(self, key) -> bool:
         """ Check to see if APIs are included in the instructions and if the key is included in specified apis """
 
@@ -336,7 +349,8 @@ class DemGenerator(BaseProcessor):
                                  drop_offshore_lidar=self.get_instruction_general('drop_offshore_lidar'),
                                  keep_only_ground_lidar=self.get_instruction_general('keep_only_ground_lidar'),
                                  tile_index_file=lidar_dataset_info['tile_index_file'],
-                                 chunk_size=self.get_instruction_general('chunk_size'))
+                                 chunk_size=self.get_processing_instructions('chunk_size'),
+                                 number_of_cores=self.get_processing_instructions('number_of_cores'))
 
         # Load in reference DEM if any significant land/foreshore not covered by LiDAR
         area_without_lidar = \

--- a/src/geofabrics/processor.py
+++ b/src/geofabrics/processor.py
@@ -91,7 +91,7 @@ class BaseProcessor(abc.ABC):
         """ Return the general instruction from the instruction file or return the default value if not specified in
         the instruction file. Raise an error if the key is not in the instructions and there is no default value. """
 
-        defaults = {'filter_lidar_holes_area': None, 'set_dem_shoreline': True,
+        defaults = {'set_dem_shoreline': True,
                     'bathymetry_contours_z_label': None, 'drop_offshore_lidar': True, 'keep_only_ground_lidar': True,
                     'interpolate_missing_values': True, 'chunk_size': None}
 
@@ -333,7 +333,6 @@ class DemGenerator(BaseProcessor):
         # setup dense DEM and catchment LiDAR objects
         self.dense_dem = dem.DenseDemFromTiles(
             catchment_geometry=self.catchment_geometry,
-            area_to_drop=self.get_instruction_general('filter_lidar_holes_area'),
             drop_offshore_lidar=self.get_instruction_general('drop_offshore_lidar'),
             interpolate_missing_values=self.get_instruction_general('interpolate_missing_values'),
             idw_power=idw_power, idw_radius=idw_radius)

--- a/src/geofabrics/processor.py
+++ b/src/geofabrics/processor.py
@@ -290,7 +290,6 @@ class DemGenerator(BaseProcessor):
 
     The `DemGenerator` class contains several important class members:
      * catchment_geometry - Defines all relevant regions in a catchment required in the generation of a DEM as polygons.
-     * catchment_lidar - Supports the addition of LiDAR data tile by tile
      * dense_dem - Defines the hydrologically conditioned DEM as a combination of tiles from LiDAR and interpolated from
        bathymetry.
      * reference_dem - This optional object defines a background DEM that may be used to fill on land gaps in the LiDAR.
@@ -304,7 +303,6 @@ class DemGenerator(BaseProcessor):
 
         super(DemGenerator, self).__init__(json_instructions=json_instructions)
 
-        self.catchment_lidar = None
         self.dense_dem = None
         self.reference_dem = None
         self.bathy_contours = None

--- a/src/geofabrics/processor.py
+++ b/src/geofabrics/processor.py
@@ -93,7 +93,7 @@ class BaseProcessor(abc.ABC):
 
         defaults = {'filter_lidar_holes_area': None, 'verbose': True, 'set_dem_shoreline': True,
                     'bathymetry_contours_z_label': None, 'drop_offshore_lidar': True, 'keep_only_ground_lidar': True,
-                    'interpolate_missing_values': True}
+                    'interpolate_missing_values': True, 'chunk_size': None}
 
         assert key in defaults or key in self.instructions['instructions']['general'], f"The key: {key} is missing " \
             + "from the general instructions, and does not have a default value"
@@ -335,7 +335,8 @@ class DemGenerator(BaseProcessor):
         self.dense_dem.add_lidar(lidar_files=lidar_dataset_info['file_paths'], source_crs=lidar_dataset_info['crs'],
                                  drop_offshore_lidar=self.get_instruction_general('drop_offshore_lidar'),
                                  keep_only_ground_lidar=self.get_instruction_general('keep_only_ground_lidar'),
-                                 tile_index_file=lidar_dataset_info['tile_index_file'], chunk_size=100)
+                                 tile_index_file=lidar_dataset_info['tile_index_file'],
+                                 chunk_size=self.get_instruction_general('chunk_size'))
 
         # Load in reference DEM if any significant land/foreshore not covered by LiDAR
         area_without_lidar = \

--- a/src/geofabrics/processor.py
+++ b/src/geofabrics/processor.py
@@ -103,8 +103,8 @@ class BaseProcessor(abc.ABC):
             return defaults[key]
 
     def get_processing_instructions(self, key: str):
-        """ Return the general instruction from the instruction file or return the default value if not specified in
-        the instruction file. Raise an error if the key is not in the instructions and there is no default value. """
+        """ Return the processing instruction from the instruction file or return the default value if not specified in
+        the instruction file. """
 
         defaults = {'number_of_cores': 1, "chunk_size": None}
 
@@ -307,7 +307,8 @@ class DemGenerator(BaseProcessor):
     def run(self):
         """ This method executes the geofabrics generation pipeline to produce geofabric derivatives.
 
-        Note it currently only considers one LiDAR dataset. See 'get_lidar_file_list' for where to change this. """
+        Note it currently only considers one LiDAR dataset that can have many tiles.
+        See 'get_lidar_file_list' for where to change this. """
 
         # Only include data in addition to LiDAR if the area_threshold is not covered
         area_threshold = 10.0/100  # Used to decide if a background DEM or bathymetry should be included
@@ -423,7 +424,8 @@ class OffshoreDemGenerator(BaseProcessor):
     def run(self):
         """ This method executes the geofabrics generation pipeline to produce geofabric derivatives.
 
-        Note it currently only considers one LiDAR dataset. See 'get_lidar_file_list' for where to change this. """
+        Note it currently only considers one LiDAR dataset that may have many tiles.
+        See 'get_lidar_file_list' for where to change this. """
 
         # Only include data in addition to LiDAR if the area_threshold is not covered
         area_threshold = 10.0/100  # Used to decide if bathymetry should be included

--- a/src/main.py
+++ b/src/main.py
@@ -29,11 +29,10 @@ def parse_args():
 def launch_processor(args):
     """ Run the pipeline over the specified instructions and compare the result to the benchmark """
 
-    # load the instructions
+    # Load the instructions
     with open(args.instructions, 'r') as file_pointer:
         instructions = json.load(file_pointer)
 
-    # run the pipeline
     assert 'local_cache' in instructions['instructions']['data_paths'], "A local_cache must be spcified in the instruction file" \
         "this is where the log file will be written."
 
@@ -42,14 +41,15 @@ def launch_processor(args):
     logging.basicConfig(filename=log_path / 'geofabrics.log', encoding='utf-8', level=logging.INFO, force=True)
     print(f"Log file is located at: {log_path / 'geofabrics.log'}")
 
+    # Run the pipeline
     start_time = time.time()
     if 'dense_dem' in instructions['instructions']['data_paths']:
-        # update a dense DEM with offshore values
+        # Update a dense DEM with offshore values
         print("Run processor.OffshoreDemGenerator")
         runner = processor.OffshoreDemGenerator(instructions)
         runner.run()
     else:
-        # create a DEM from dense data (LiDAR, reference DEM) and bathymetry if specified
+        # Create a DEM from dense data (LiDAR, reference DEM) and bathymetry if specified
         print("Run processor.DemGenerator")
         runner = processor.DemGenerator(instructions)
         runner.run()
@@ -57,7 +57,7 @@ def launch_processor(args):
 
     print(f"Execution time is {end_time - start_time}")
 
-    # load in benchmark DEM and compare - if specified in the instructions
+    # Load in benchmark DEM and compare - if specified in the instructions
     if 'benchmark_dem' in instructions['instructions']['data_paths']:
         with rioxarray.rioxarray.open_rasterio(instructions['instructions']['data_paths']['benchmark_dem'],
                                                masked=True) as benchmark_dem:
@@ -65,7 +65,7 @@ def launch_processor(args):
         logging.info(f"Comparing the generated DEM saved at {instructions['instructions']['data_paths']['result_dem']} "
                      f"against the benchmark DEM stored {instructions['instructions']['data_paths']['benchmark_dem']} "
                      "\nAny difference will be reported.")
-        # compare the generated and benchmark DEMs - plot
+        # Compare the generated and benchmark DEMs - plot
         diff = benchmark_dem.copy()
         diff.data = runner.result_dem.data - benchmark_dem.data
 

--- a/src/main.py
+++ b/src/main.py
@@ -11,6 +11,7 @@ import rioxarray
 import numpy
 import matplotlib
 import time
+import logging
 
 
 def parse_args():
@@ -26,6 +27,8 @@ def parse_args():
 
 def launch_processor(args):
     """ Run the pipeline over the specified instructions and compare the result to the benchmark """
+
+    logging.basicConfig(filename='geofabrics.debug', encoding='utf-8', level=logging.INFO)
 
     # load the instructions
     with open(args.instructions, 'r') as file_pointer:
@@ -52,9 +55,9 @@ def launch_processor(args):
         with rioxarray.rioxarray.open_rasterio(instructions['instructions']['data_paths']['benchmark_dem'],
                                                masked=True) as benchmark_dem:
             benchmark_dem.load()
-        print(f"Comparing the generated DEM saved at {instructions['instructions']['data_paths']['result_dem']} " +
-              f"against the benchmark DEM stored {instructions['instructions']['data_paths']['benchmark_dem']}\n Any " +
-              "difference will be reported.")
+        logging.info(f"Comparing the generated DEM saved at {instructions['instructions']['data_paths']['result_dem']} "
+                     f"against the benchmark DEM stored {instructions['instructions']['data_paths']['benchmark_dem']} "
+                     "\nAny difference will be reported.")
         # compare the generated and benchmark DEMs - plot
         diff = benchmark_dem.copy()
         diff.data = runner.result_dem.data - benchmark_dem.data

--- a/src/main.py
+++ b/src/main.py
@@ -39,6 +39,7 @@ def launch_processor(args):
 
     # Setup logging
     log_path = pathlib.Path(instructions['instructions']['data_paths']['local_cache'])
+    log_path.mkdir(parents=True, exist_ok=True)
     logging.basicConfig(filename=log_path / 'geofabrics.log', encoding='utf-8', level=logging.INFO, force=True)
     print(f"Log file is located at: {log_path / 'geofabrics.log'}")
 

--- a/src/main.py
+++ b/src/main.py
@@ -27,7 +27,8 @@ def parse_args():
 
 
 def launch_processor(args):
-    """ Run the pipeline over the specified instructions and compare the result to the benchmark """
+    """ Run the DEM generation pipeline given the specified instructions.
+    If a benchmark is specified compare the result to the benchmark """
 
     # Load the instructions
     with open(args.instructions, 'r') as file_pointer:
@@ -91,6 +92,7 @@ def launch_processor(args):
 
 
 def main():
+    """ The entry point to geofabrics. """
     args = parse_args()
     launch_processor(args)
 

--- a/src/main.py
+++ b/src/main.py
@@ -12,6 +12,7 @@ import numpy
 import matplotlib
 import time
 import logging
+import pathlib
 
 
 def parse_args():
@@ -28,13 +29,19 @@ def parse_args():
 def launch_processor(args):
     """ Run the pipeline over the specified instructions and compare the result to the benchmark """
 
-    logging.basicConfig(filename='geofabrics.debug', encoding='utf-8', level=logging.INFO)
-
     # load the instructions
     with open(args.instructions, 'r') as file_pointer:
         instructions = json.load(file_pointer)
 
     # run the pipeline
+    assert 'local_cache' in instructions['instructions']['data_paths'], "A local_cache must be spcified in the instruction file" \
+        "this is where the log file will be written."
+
+    # Setup logging
+    log_path = pathlib.Path(instructions['instructions']['data_paths']['local_cache'])
+    logging.basicConfig(filename=log_path / 'geofabrics.log', encoding='utf-8', level=logging.INFO, force=True)
+    print(f"Log file is located at: {log_path / 'geofabrics.log'}")
+
     start_time = time.time()
     if 'dense_dem' in instructions['instructions']['data_paths']:
         # update a dense DEM with offshore values

--- a/tests/test_processor_local_files/data/benchmark_dem.nc
+++ b/tests/test_processor_local_files/data/benchmark_dem.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:58de932afa713123166b9ac22b7654ddb0064814c53df2e1d04c3dcc44a8937b
+oid sha256:e7851bbb5a70ed2f576621fb6287392fbf69bdeb61b0389702c209b3d0c19fe5
 size 84552

--- a/tests/test_processor_local_files/instruction.json
+++ b/tests/test_processor_local_files/instruction.json
@@ -10,12 +10,12 @@
 			}
 		},
 		"data_paths": {
+			"local_cache": "tests/test_processor_local_files_offshore_after/data",
 			"catchment_boundary": "tests/test_processor_local_files/data/catchment_boundary.zip",
 			"land": "tests/test_processor_local_files/data/land.zip",
 			"lidars": ["tests/test_processor_local_files/data/lidar.laz"],
 			"reference_dems": ["tests/test_processor_local_files/data/reference_dem.nc"],
 			"bathymetry_contours": ["tests/test_processor_local_files/data/bathymetry.zip"],
-			"temp_raster": "tests/test_processor_local_files/data/temp_dense_dem.tif",
 			"result_dem": "tests/test_processor_local_files/data/test_dem.nc",
 			"dense_dem_extents": "tests/test_processor_local_files/data/extents.geojson",
 			"benchmark_dem": "tests/test_processor_local_files/data/benchmark_dem.nc"

--- a/tests/test_processor_local_files/test_processor_local_files.py
+++ b/tests/test_processor_local_files/test_processor_local_files.py
@@ -15,6 +15,7 @@ import numpy
 import shapely
 import geopandas
 import pdal
+import logging
 
 from src.geofabrics import processor
 
@@ -35,6 +36,10 @@ class ProcessorLocalFilesTest(unittest.TestCase):
         in the tests. """
 
         test_path = pathlib.Path().cwd() / pathlib.Path("tests/test_processor_local_files")
+
+        # Setup logging
+        logging.basicConfig(filename=test_path / 'test.log', encoding='utf-8', level=logging.INFO, force=True)
+        logging.info("In test_processor_local_files.py")
 
         # Load in the test instructions
         instruction_file_path = test_path / "instruction.json"
@@ -169,7 +174,7 @@ class ProcessorLocalFilesTest(unittest.TestCase):
 
         # Compare DEMs - load both from file as rioxarray.rioxarray.open_rasterio ignores index order
         diff_array = test_dem.data-benchmark_dem.data
-        print(f"DEM array diff is: {diff_array[diff_array != 0]}")
+        logging.info(f"DEM array diff is: {diff_array[diff_array != 0]}")
         numpy.testing.assert_array_almost_equal(test_dem.data, benchmark_dem.data,
                                                 err_msg="The generated result_dem has different data from the " +
                                                 "benchmark_dem")

--- a/tests/test_processor_local_files_limited_offshore_res/instruction.json
+++ b/tests/test_processor_local_files_limited_offshore_res/instruction.json
@@ -22,8 +22,7 @@
 		"general": {
 			"set_dem_shoreline": true,
 			"drop_offshore_lidar": true,
-			"keep_only_ground_lidar": true,
-			"filter_lidar_holes_area": 1
+			"keep_only_ground_lidar": true
 		}
 	}
 }

--- a/tests/test_processor_local_files_limited_offshore_res/instruction.json
+++ b/tests/test_processor_local_files_limited_offshore_res/instruction.json
@@ -10,11 +10,11 @@
 			}
 		},
 		"data_paths": {
+			"local_cache": "tests/test_processor_local_files_offshore_after/data",
 			"catchment_boundary": "tests/test_processor_local_files_limited_offshore_res/data/catchment_boundary.zip",
 			"land": "tests/test_processor_local_files_limited_offshore_res/data/land.zip",
 			"lidars": ["tests/test_processor_local_files_limited_offshore_res/data/lidar.laz"],
 			"bathymetry_contours": ["tests/test_processor_local_files_limited_offshore_res/data/bathymetry.zip"],
-			"temp_raster": "tests/test_processor_local_files_limited_offshore_res/data/temp_dense_dem.tif",
 			"result_dem": "tests/test_processor_local_files_limited_offshore_res/data/test_dem.nc",
 			"dense_dem_extents": "tests/test_processor_local_files_limited_offshore_res/data/extents.geojson",
 			"benchmark_dem": "tests/test_processor_local_files_limited_offshore_res/data/benchmark_dem.nc"

--- a/tests/test_processor_local_files_limited_offshore_res/test_processor_local_files_limited_offshore_res.py
+++ b/tests/test_processor_local_files_limited_offshore_res/test_processor_local_files_limited_offshore_res.py
@@ -16,6 +16,7 @@ import geopandas
 import pdal
 import pytest
 import sys
+import logging
 
 from src.geofabrics import processor
 
@@ -39,6 +40,10 @@ class ProcessorLocalFilesTest(unittest.TestCase):
         in the tests. """
 
         test_path = pathlib.Path().cwd() / pathlib.Path("tests/test_processor_local_files_limited_offshore_res")
+
+        # Setup logging
+        logging.basicConfig(filename=test_path / 'test.log', encoding='utf-8', level=logging.INFO, force=True)
+        logging.info("In test_processor_local_files_limited_offshore.py")
 
         # Load in the test instructions
         instruction_file_path = test_path / "instruction.json"
@@ -160,7 +165,7 @@ class ProcessorLocalFilesTest(unittest.TestCase):
 
         # Compare DEMs - load from file as rioxarray.rioxarray.open_rasterio ignores index order
         diff_array = test_dem.data-benchmark_dem.data
-        print(f"DEM array diff is: {diff_array[diff_array != 0]}")
+        logging.info(f"DEM array diff is: {diff_array[diff_array != 0]}")
         numpy.testing.assert_array_equal(test_dem.data, benchmark_dem.data,
                                          err_msg="The generated result_dem has different data from the benchmark_dem")
 
@@ -184,7 +189,7 @@ class ProcessorLocalFilesTest(unittest.TestCase):
 
         # Compare DEMs - load both from file as rioxarray.rioxarray.open_rasterio ignores index order
         diff_array = test_dem.data-benchmark_dem.data
-        print(f"DEM array diff is: {diff_array[diff_array != 0]}")
+        logging.info(f"DEM array diff is: {diff_array[diff_array != 0]}")
         numpy.testing.assert_array_almost_equal(test_dem.data, benchmark_dem.data,
                                                 err_msg="The generated result_dem has different data from the " +
                                                 "benchmark_dem")

--- a/tests/test_processor_local_files_offshore_after/data/benchmark_dem.nc
+++ b/tests/test_processor_local_files_offshore_after/data/benchmark_dem.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:706468a09fb54192452fe5675cf14d113e162da14eb30f011ef3418bf9b40272
+oid sha256:2bd196ab1b44e0c0bcc9345093a502df39a8b011677b75dce64ddf5f246e52b3
 size 84552

--- a/tests/test_processor_local_files_offshore_after/instruction.json
+++ b/tests/test_processor_local_files_offshore_after/instruction.json
@@ -10,12 +10,12 @@
 			}
 		},
 		"data_paths": {
+			"local_cache": "tests/test_processor_local_files_offshore_after/data",
 			"catchment_boundary": "tests/test_processor_local_files_offshore_after/data/catchment_boundary.zip",
 			"land": "tests/test_processor_local_files_offshore_after/data/land.zip",
 			"lidars": ["tests/test_processor_local_files_offshore_after/data/lidar.laz"],
 			"reference_dems": ["tests/test_processor_local_files_offshore_after/data/reference_dem.nc"],
 			"bathymetry_contours": ["tests/test_processor_local_files_offshore_after/data/bathymetry.zip"],
-			"temp_raster": "tests/test_processor_local_files_offshore_after/data/temp_dense_dem.tif",
 			"dense_dem_extents": "tests/test_processor_local_files_offshore_after/data/extents.geojson",
 			"result_dem": "tests/test_processor_local_files_offshore_after/data/dense_dem.nc",
 			"final_result_dem": "tests/test_processor_local_files_offshore_after/data/test_dem.nc",

--- a/tests/test_processor_local_files_offshore_after/test_processor_local_files_offshore_after.py
+++ b/tests/test_processor_local_files_offshore_after/test_processor_local_files_offshore_after.py
@@ -174,7 +174,6 @@ class ProcessorLocalFilesTest(unittest.TestCase):
             self.instructions['instructions']['data_paths']['final_result_dem']
         self.instructions['instructions']['data_paths'].pop('lidars')
         self.instructions['instructions']['data_paths'].pop('reference_dems')
-        self.instructions['instructions']['data_paths'].pop('temp_raster')
         self.instructions['instructions']['data_paths'].pop('final_result_dem')
         runner = processor.OffshoreDemGenerator(self.instructions)
         runner.run()

--- a/tests/test_processor_local_files_offshore_after/test_processor_local_files_offshore_after.py
+++ b/tests/test_processor_local_files_offshore_after/test_processor_local_files_offshore_after.py
@@ -16,6 +16,7 @@ import shapely
 import geopandas
 import pdal
 import copy
+import logging
 
 from src.geofabrics import processor
 
@@ -36,6 +37,10 @@ class ProcessorLocalFilesTest(unittest.TestCase):
         in the tests. """
 
         test_path = pathlib.Path().cwd() / pathlib.Path("tests/test_processor_local_files_offshore_after")
+
+        # Setup logging
+        logging.basicConfig(filename=test_path / 'test.log', encoding='utf-8', level=logging.INFO, force=True)
+        logging.info("In test_processor_local_files_offshore_after.py")
 
         # Load in the test instructions
         instruction_file_path = test_path / "instruction.json"
@@ -186,7 +191,7 @@ class ProcessorLocalFilesTest(unittest.TestCase):
 
         # Compare DEMs - load both from file as rioxarray.rioxarray.open_rasterio ignores index order
         diff_array = test_dem.data[~numpy.isnan(test_dem.data)]-benchmark_dem.data[~numpy.isnan(benchmark_dem.data)]
-        print(f"DEM array diff is: {diff_array[diff_array != 0]}")
+        logging.info(f"DEM array diff is: {diff_array[diff_array != 0]}")
         numpy.testing.assert_array_almost_equal(test_dem.data, benchmark_dem.data,
                                                 err_msg="The generated result_dem has different data from the " +
                                                 "benchmark_dem")

--- a/tests/test_processor_local_files_offshore_after/test_processor_local_files_offshore_after.py
+++ b/tests/test_processor_local_files_offshore_after/test_processor_local_files_offshore_after.py
@@ -21,8 +21,8 @@ from src.geofabrics import processor
 
 
 class ProcessorLocalFilesTest(unittest.TestCase):
-    """ A class to test the basic DemGenerator processor class for a simple example with land, offshore, a reference DEM and
-    LiDAR using the data specified in the test1/instruction.json
+    """ A class to test the basic DemGenerator processor class for a simple example with land, offshore, a reference DEM
+    and LiDAR using the data specified in the instruction.json
 
     Tests run include:
         1. test_result_dem  Check the generated DEM matches the benchmark DEM within a tolerance
@@ -185,7 +185,7 @@ class ProcessorLocalFilesTest(unittest.TestCase):
             test_dem.load()
 
         # Compare DEMs - load both from file as rioxarray.rioxarray.open_rasterio ignores index order
-        diff_array = test_dem.data-benchmark_dem.data
+        diff_array = test_dem.data[~numpy.isnan(test_dem.data)]-benchmark_dem.data[~numpy.isnan(benchmark_dem.data)]
         print(f"DEM array diff is: {diff_array[diff_array != 0]}")
         numpy.testing.assert_array_almost_equal(test_dem.data, benchmark_dem.data,
                                                 err_msg="The generated result_dem has different data from the " +

--- a/tests/test_processor_remote_all_westport/data/benchmark_dem.nc
+++ b/tests/test_processor_remote_all_westport/data/benchmark_dem.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f20e1a80ab5ebdb0e9e1808126051fc643357b83eaacbb7d59d9d33d80c13683
+oid sha256:2d9d28c2528a4c6f8198f47f3e8e5c319d0261a406f125cf3a58376ae1d7e090
 size 186952

--- a/tests/test_processor_remote_all_westport/data/benchmark_dem.nc
+++ b/tests/test_processor_remote_all_westport/data/benchmark_dem.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:28005943257a9fe08e2d32ec76d2d756ae831b29066660589faf85ca80ffec72
+oid sha256:f20e1a80ab5ebdb0e9e1808126051fc643357b83eaacbb7d59d9d33d80c13683
 size 186952

--- a/tests/test_processor_remote_all_westport/data/benchmark_dem.nc
+++ b/tests/test_processor_remote_all_westport/data/benchmark_dem.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2d9d28c2528a4c6f8198f47f3e8e5c319d0261a406f125cf3a58376ae1d7e090
+oid sha256:f20e1a80ab5ebdb0e9e1808126051fc643357b83eaacbb7d59d9d33d80c13683
 size 186952

--- a/tests/test_processor_remote_all_westport/instruction.json
+++ b/tests/test_processor_remote_all_westport/instruction.json
@@ -9,6 +9,10 @@
 				"resolution": 10
 			}
 		},
+		"processing": {
+			"chunk_size": 200,
+			"number_of_cores": 1
+		},
 		"data_paths": {
 			"local_cache": "tests/test_processor_remote_all_westport/data",
 			"catchment_boundary": "tests/test_processor_remote_all_westport/data/catchment.zip",
@@ -31,8 +35,7 @@
 		"general": {
 			"drop_offshore_lidar": true,
 			"bathymetry_contours_z_label": "valdco",
-			"keep_only_ground_lidar": false,
-			"chunk_size": 200
+			"keep_only_ground_lidar": false
 		}
 	}
 }

--- a/tests/test_processor_remote_all_westport/instruction.json
+++ b/tests/test_processor_remote_all_westport/instruction.json
@@ -31,7 +31,8 @@
 		"general": {
 			"drop_offshore_lidar": true,
 			"bathymetry_contours_z_label": "valdco",
-			"keep_only_ground_lidar": false
+			"keep_only_ground_lidar": false,
+			"chunk_size": 200
 		}
 	}
 }

--- a/tests/test_processor_remote_all_westport/instruction.json
+++ b/tests/test_processor_remote_all_westport/instruction.json
@@ -11,7 +11,7 @@
 		},
 		"processing": {
 			"chunk_size": 200,
-			"number_of_cores": 1
+			"number_of_cores": 2
 		},
 		"data_paths": {
 			"local_cache": "tests/test_processor_remote_all_westport/data",

--- a/tests/test_processor_remote_all_westport/test_processor_remote_all_westport.py
+++ b/tests/test_processor_remote_all_westport/test_processor_remote_all_westport.py
@@ -17,6 +17,7 @@ import pytest
 import sys
 import dotenv
 import os
+import logging
 
 from src.geofabrics import processor
 
@@ -47,6 +48,10 @@ class ProcessorRemoteAllWestportTest(unittest.TestCase):
         files and produce a DEM prior to testing. """
 
         test_path = pathlib.Path().cwd() / pathlib.Path("tests/test_processor_remote_all_westport")
+
+        # Setup logging
+        logging.basicConfig(filename=test_path / 'test.log', encoding='utf-8', level=logging.INFO, force=True)
+        logging.info("In test_processor_remote_all_westport.py")
 
         # Load in the test instructions
         instruction_file_path = test_path / "instruction.json"
@@ -165,7 +170,7 @@ class ProcessorRemoteAllWestportTest(unittest.TestCase):
 
         # Compare DEMs - load both from file as rioxarray.rioxarray.open_rasterio ignores index order
         diff_array = test_dem.data[~numpy.isnan(test_dem.data)]-benchmark_dem.data[~numpy.isnan(benchmark_dem.data)]
-        print(f"DEM array diff is: {diff_array[diff_array != 0]}")
+        logging.info(f"DEM array diff is: {diff_array[diff_array != 0]}")
         numpy.testing.assert_array_almost_equal(test_dem.data[~numpy.isnan(test_dem.data)],
                                                 benchmark_dem.data[~numpy.isnan(benchmark_dem.data)],
                                                 err_msg="The generated result_dem has different data from the " +
@@ -187,7 +192,7 @@ class ProcessorRemoteAllWestportTest(unittest.TestCase):
 
         # Compare the generated and benchmark DEMs
         diff_array = test_dem.data[~numpy.isnan(test_dem.data)]-benchmark_dem.data[~numpy.isnan(benchmark_dem.data)]
-        print(f"DEM array diff is: {diff_array[diff_array != 0]}")
+        logging.info(f"DEM array diff is: {diff_array[diff_array != 0]}")
 
         threshold = 10e-2
         allowable_number_above = 2

--- a/tests/test_processor_remote_all_westport_ground_only/data/benchmark_dem.nc
+++ b/tests/test_processor_remote_all_westport_ground_only/data/benchmark_dem.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2cb23954c95b019f554586d9fcd4dcef8c9a96244ef166d511a6018933918cae
+oid sha256:c11f7ab799a867cfb7663c0e4e31dff7d780654a40b6f6a358b16c51131f1ddb
 size 186952

--- a/tests/test_processor_remote_all_westport_ground_only/data/benchmark_dem.nc
+++ b/tests/test_processor_remote_all_westport_ground_only/data/benchmark_dem.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c11f7ab799a867cfb7663c0e4e31dff7d780654a40b6f6a358b16c51131f1ddb
+oid sha256:2cb23954c95b019f554586d9fcd4dcef8c9a96244ef166d511a6018933918cae
 size 186952

--- a/tests/test_processor_remote_all_westport_ground_only/data/benchmark_dem.nc
+++ b/tests/test_processor_remote_all_westport_ground_only/data/benchmark_dem.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0d0ba390176d36585016e690edccbdbd626c3e6efbb114cca53010476577b326
+oid sha256:c11f7ab799a867cfb7663c0e4e31dff7d780654a40b6f6a358b16c51131f1ddb
 size 186952

--- a/tests/test_processor_remote_all_westport_ground_only/instruction.json
+++ b/tests/test_processor_remote_all_westport_ground_only/instruction.json
@@ -11,7 +11,7 @@
 		},
 		"processing": {
 			"chunk_size": 200,
-			"number_of_cores": 1
+			"number_of_cores": 2
 		},
 		"data_paths": {
 			"local_cache": "tests/test_processor_remote_all_westport_ground_only/data",

--- a/tests/test_processor_remote_all_westport_ground_only/instruction.json
+++ b/tests/test_processor_remote_all_westport_ground_only/instruction.json
@@ -9,6 +9,10 @@
 				"resolution": 10
 			}
 		},
+		"processing": {
+			"chunk_size": 200,
+			"number_of_cores": 1
+		},
 		"data_paths": {
 			"local_cache": "tests/test_processor_remote_all_westport_ground_only/data",
 			"catchment_boundary": "tests/test_processor_remote_all_westport_ground_only/data/catchment.zip",
@@ -30,8 +34,7 @@
 		"general": {
 			"drop_offshore_lidar": true,
 			"bathymetry_contours_z_label": "valdco",
-			"keep_only_ground_lidar": true,
-			"chunk_size": 200
+			"keep_only_ground_lidar": true
 		}
 	}
 }

--- a/tests/test_processor_remote_all_westport_ground_only/instruction.json
+++ b/tests/test_processor_remote_all_westport_ground_only/instruction.json
@@ -30,7 +30,8 @@
 		"general": {
 			"drop_offshore_lidar": true,
 			"bathymetry_contours_z_label": "valdco",
-			"keep_only_ground_lidar": true
+			"keep_only_ground_lidar": true,
+			"chunk_size": 200
 		}
 	}
 }

--- a/tests/test_processor_remote_all_westport_ground_only/test_processor_remote_all_westport_ground_only.py
+++ b/tests/test_processor_remote_all_westport_ground_only/test_processor_remote_all_westport_ground_only.py
@@ -17,6 +17,7 @@ import pytest
 import sys
 import dotenv
 import os
+import logging
 
 from src.geofabrics import processor
 
@@ -50,6 +51,10 @@ class ProcessorRemoteAllWestportTest(unittest.TestCase):
         files and produce a DEM prior to testing. """
 
         test_path = pathlib.Path().cwd() / pathlib.Path("tests/test_processor_remote_all_westport_ground_only")
+
+        # Setup logging
+        logging.basicConfig(filename=test_path / 'test.log', encoding='utf-8', level=logging.INFO, force=True)
+        logging.info("In test_processor_remote_all_westport_ground_only.py")
 
         # Load in the test instructions
         instruction_file_path = test_path / "instruction.json"
@@ -168,7 +173,7 @@ class ProcessorRemoteAllWestportTest(unittest.TestCase):
 
         # Compare the generated and benchmark DEMs
         diff_array = test_dem.data[~numpy.isnan(test_dem.data)]-benchmark_dem.data[~numpy.isnan(benchmark_dem.data)]
-        print(f"DEM array diff is: {diff_array[diff_array != 0]}")
+        logging.info(f"DEM array diff is: {diff_array[diff_array != 0]}")
         numpy.testing.assert_array_almost_equal(test_dem.data[~numpy.isnan(test_dem.data)],
                                                 benchmark_dem.data[~numpy.isnan(benchmark_dem.data)],
                                                 err_msg="The generated result_dem has different data from the " +
@@ -190,7 +195,7 @@ class ProcessorRemoteAllWestportTest(unittest.TestCase):
 
         # Compare the generated and benchmark DEMs
         diff_array = test_dem.data[~numpy.isnan(test_dem.data)]-benchmark_dem.data[~numpy.isnan(benchmark_dem.data)]
-        print(f"DEM array diff is: {diff_array[diff_array != 0]}")
+        logging.info(f"DEM array diff is: {diff_array[diff_array != 0]}")
 
         threshold = 10e-2
         allowable_number_above = 5

--- a/tests/test_processor_remote_tiles_wellington/data/benchmark_dem.nc
+++ b/tests/test_processor_remote_tiles_wellington/data/benchmark_dem.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b50e586e2fec3263ac40d577be8d09213574dd2c76ecf36053dba592c8714c60
+oid sha256:2b07c5b957ca3de8cbda334299eae16db51a2157294bfd3edf4990e38f89f6e0
 size 62472

--- a/tests/test_processor_remote_tiles_wellington/instruction.json
+++ b/tests/test_processor_remote_tiles_wellington/instruction.json
@@ -9,6 +9,10 @@
 				"resolution": 10
 			}
 		},
+		"processing": {
+			"chunk_size": 100,
+			"number_of_cores": 1
+		},
 		"data_paths": {
 		  "local_cache": "tests/test_processor_remote_tiles_wellington/data",
 		  "catchment_boundary": "tests/test_processor_remote_tiles_wellington/data/catchment.zip",
@@ -30,8 +34,7 @@
 		"general": {
 		  "set_dem_shoreline": true,
 			"drop_offshore_lidar": false,
-			"keep_only_ground_lidar": false,
-			"chunk_size": 100
+			"keep_only_ground_lidar": false
 		}
 	}
 }

--- a/tests/test_processor_remote_tiles_wellington/instruction.json
+++ b/tests/test_processor_remote_tiles_wellington/instruction.json
@@ -13,7 +13,6 @@
 		  "local_cache": "tests/test_processor_remote_tiles_wellington/data",
 		  "catchment_boundary": "tests/test_processor_remote_tiles_wellington/data/catchment.zip",
 		  "land": "tests/test_processor_remote_tiles_wellington/data/catchment.zip",
-		  "temp_raster": "tests/test_processor_remote_tiles_wellington/data/temp_dense_dem.tif",
 		  "result_dem": "tests/test_processor_remote_tiles_wellington/data/test_dem.nc",
 		  "dense_dem_extents": "tests/test_processor_remote_tiles_wellington/data/extents.geojson",
 		  "benchmark_dem": "tests/test_processor_remote_tiles_wellington/data/benchmark_dem.nc"

--- a/tests/test_processor_remote_tiles_wellington/instruction.json
+++ b/tests/test_processor_remote_tiles_wellington/instruction.json
@@ -30,7 +30,8 @@
 		"general": {
 		  "set_dem_shoreline": true,
 			"drop_offshore_lidar": false,
-			"keep_only_ground_lidar": false
+			"keep_only_ground_lidar": false,
+			"chunk_size": 100
 		}
 	}
 }

--- a/tests/test_processor_remote_tiles_wellington/test_processor_remote_tiles_wellington.py
+++ b/tests/test_processor_remote_tiles_wellington/test_processor_remote_tiles_wellington.py
@@ -15,6 +15,7 @@ import numpy
 import rioxarray
 import pytest
 import sys
+import logging
 
 from src.geofabrics import processor
 
@@ -43,6 +44,10 @@ class ProcessorRemoteTilesWellingtonTest(unittest.TestCase):
         files and produce a DEM prior to testing. """
 
         test_path = pathlib.Path().cwd() / pathlib.Path("tests/test_processor_remote_tiles_wellington")
+
+        # Setup logging
+        logging.basicConfig(filename=test_path / 'test.log', encoding='utf-8', level=logging.INFO, force=True)
+        logging.info("In test_processor_remote_tiles_wellington.py")
 
         # load in the test instructions
         instruction_file_path = test_path / "instruction.json"
@@ -150,7 +155,7 @@ class ProcessorRemoteTilesWellingtonTest(unittest.TestCase):
 
         # compare the generated and benchmark DEMs
         diff_array = test_dem.data[~numpy.isnan(test_dem.data)]-benchmark_dem.data[~numpy.isnan(benchmark_dem.data)]
-        print(f"DEM array diff is: {diff_array[diff_array != 0]}")
+        logging.info(f"DEM array diff is: {diff_array[diff_array != 0]}")
         numpy.testing.assert_array_almost_equal(test_dem.data, benchmark_dem.data,
                                                 err_msg="The generated result_dem has different data from the " +
                                                 "benchmark_dem")
@@ -171,7 +176,7 @@ class ProcessorRemoteTilesWellingtonTest(unittest.TestCase):
 
         # compare the generated and benchmark DEMs
         diff_array = test_dem.data[~numpy.isnan(test_dem.data)]-benchmark_dem.data[~numpy.isnan(benchmark_dem.data)]
-        print(f"DEM array diff is: {diff_array[diff_array != 0]}")
+        logging.info(f"DEM array diff is: {diff_array[diff_array != 0]}")
 
         threshold = 10e-6
         self.assertTrue(len(diff_array[diff_array != 0]) < len(diff_array) / 100, f"{len(diff_array[diff_array != 0])} "

--- a/tests/test_processor_remote_tiles_wellington/test_processor_remote_tiles_wellington.py
+++ b/tests/test_processor_remote_tiles_wellington/test_processor_remote_tiles_wellington.py
@@ -149,7 +149,7 @@ class ProcessorRemoteTilesWellingtonTest(unittest.TestCase):
             test_dem.load()
 
         # compare the generated and benchmark DEMs
-        diff_array = test_dem.data-benchmark_dem.data
+        diff_array = test_dem.data[~numpy.isnan(test_dem.data)]-benchmark_dem.data[~numpy.isnan(benchmark_dem.data)]
         print(f"DEM array diff is: {diff_array[diff_array != 0]}")
         numpy.testing.assert_array_almost_equal(test_dem.data, benchmark_dem.data,
                                                 err_msg="The generated result_dem has different data from the " +
@@ -170,7 +170,7 @@ class ProcessorRemoteTilesWellingtonTest(unittest.TestCase):
             test_dem.load()
 
         # compare the generated and benchmark DEMs
-        diff_array = (test_dem.data-benchmark_dem.data).flatten()
+        diff_array = test_dem.data[~numpy.isnan(test_dem.data)]-benchmark_dem.data[~numpy.isnan(benchmark_dem.data)]
         print(f"DEM array diff is: {diff_array[diff_array != 0]}")
 
         threshold = 10e-6

--- a/tests/test_processor_remote_tiles_wellington_ground_only/data/benchmark_dem.nc
+++ b/tests/test_processor_remote_tiles_wellington_ground_only/data/benchmark_dem.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b13cba53ff59ff684e7c191259fce475b291bb497bc60fc008dcde2375362afe
+oid sha256:4d133908433fdd957936a0ef7d528ff8c5777c1f13be29e93367b68cfa279444
 size 130176

--- a/tests/test_processor_remote_tiles_wellington_ground_only/instruction.json
+++ b/tests/test_processor_remote_tiles_wellington_ground_only/instruction.json
@@ -13,7 +13,6 @@
 		  "local_cache": "tests/test_processor_remote_tiles_wellington_ground_only/data",
 		  "catchment_boundary": "tests/test_processor_remote_tiles_wellington_ground_only/data/catchment.zip",
 		  "land": "tests/test_processor_remote_tiles_wellington_ground_only/data/catchment.zip",
-		  "temp_raster": "tests/test_processor_remote_tiles_wellington_ground_only/data/temp_dense_dem.tif",
 		  "result_dem": "tests/test_processor_remote_tiles_wellington_ground_only/data/test_dem.nc",
 		  "dense_dem_extents": "tests/test_processor_remote_tiles_wellington_ground_only/data/extents.geojson",
 		  "benchmark_dem": "tests/test_processor_remote_tiles_wellington_ground_only/data/benchmark_dem.nc"
@@ -31,7 +30,8 @@
 		"general": {
 		  "set_dem_shoreline": true,
 			"drop_offshore_lidar": false,
-			"keep_only_ground_lidar": true
+			"keep_only_ground_lidar": true,
+			"interpolate_missing_values": false
 		}
 	}
 }

--- a/tests/test_processor_remote_tiles_wellington_ground_only/instruction.json
+++ b/tests/test_processor_remote_tiles_wellington_ground_only/instruction.json
@@ -31,7 +31,8 @@
 		  "set_dem_shoreline": true,
 			"drop_offshore_lidar": false,
 			"keep_only_ground_lidar": true,
-			"interpolate_missing_values": false
+			"interpolate_missing_values": false,
+			"chunk_size": 100
 		}
 	}
 }

--- a/tests/test_processor_remote_tiles_wellington_ground_only/instruction.json
+++ b/tests/test_processor_remote_tiles_wellington_ground_only/instruction.json
@@ -32,7 +32,7 @@
 			}
 		},
 		"general": {
-		  "set_dem_shoreline": true,
+		    "set_dem_shoreline": true,
 			"drop_offshore_lidar": false,
 			"keep_only_ground_lidar": true,
 			"interpolate_missing_values": false

--- a/tests/test_processor_remote_tiles_wellington_ground_only/instruction.json
+++ b/tests/test_processor_remote_tiles_wellington_ground_only/instruction.json
@@ -9,6 +9,10 @@
 				"resolution": 10
 			}
 		},
+		"processing": {
+			"chunk_size": 100,
+			"number_of_cores": 1
+		},
 		"data_paths": {
 		  "local_cache": "tests/test_processor_remote_tiles_wellington_ground_only/data",
 		  "catchment_boundary": "tests/test_processor_remote_tiles_wellington_ground_only/data/catchment.zip",
@@ -31,8 +35,7 @@
 		  "set_dem_shoreline": true,
 			"drop_offshore_lidar": false,
 			"keep_only_ground_lidar": true,
-			"interpolate_missing_values": false,
-			"chunk_size": 100
+			"interpolate_missing_values": false
 		}
 	}
 }

--- a/tests/test_processor_remote_tiles_wellington_ground_only/test_processor_remote_tiles_wellington_ground_only.py
+++ b/tests/test_processor_remote_tiles_wellington_ground_only/test_processor_remote_tiles_wellington_ground_only.py
@@ -152,7 +152,7 @@ class ProcessorRemoteTilesWellingtonTest(unittest.TestCase):
             test_dem.load()
 
         # compare the generated and benchmark DEMs
-        diff_array = test_dem.data-benchmark_dem.data
+        diff_array = test_dem.data[~numpy.isnan(test_dem.data)]-benchmark_dem.data[~numpy.isnan(benchmark_dem.data)]
         print(f"DEM array diff is: {diff_array[diff_array != 0]}")
         numpy.testing.assert_array_almost_equal(test_dem.data, benchmark_dem.data,
                                                 err_msg="The generated result_dem has different data from the " +
@@ -173,7 +173,7 @@ class ProcessorRemoteTilesWellingtonTest(unittest.TestCase):
             test_dem.load()
 
         # compare the generated and benchmark DEMs
-        diff_array = (test_dem.data-benchmark_dem.data).flatten()
+        diff_array = test_dem.data[~numpy.isnan(test_dem.data)]-benchmark_dem.data[~numpy.isnan(benchmark_dem.data)]
         print(f"DEM array diff is: {diff_array[diff_array != 0]}")
 
         threshold = 10e-6

--- a/tests/test_processor_remote_tiles_wellington_ground_only/test_processor_remote_tiles_wellington_ground_only.py
+++ b/tests/test_processor_remote_tiles_wellington_ground_only/test_processor_remote_tiles_wellington_ground_only.py
@@ -15,6 +15,7 @@ import numpy
 import rioxarray
 import pytest
 import sys
+import logging
 
 from src.geofabrics import processor
 
@@ -46,6 +47,10 @@ class ProcessorRemoteTilesWellingtonTest(unittest.TestCase):
         files and produce a DEM prior to testing. """
 
         test_path = pathlib.Path().cwd() / pathlib.Path("tests/test_processor_remote_tiles_wellington_ground_only")
+
+        # Setup logging
+        logging.basicConfig(filename=test_path / 'test.log', encoding='utf-8', level=logging.INFO, force=True)
+        logging.info("In test_processor_remote_tiles_wellington_ground_only.py")
 
         # load in the test instructions
         instruction_file_path = test_path / "instruction.json"
@@ -153,7 +158,7 @@ class ProcessorRemoteTilesWellingtonTest(unittest.TestCase):
 
         # compare the generated and benchmark DEMs
         diff_array = test_dem.data[~numpy.isnan(test_dem.data)]-benchmark_dem.data[~numpy.isnan(benchmark_dem.data)]
-        print(f"DEM array diff is: {diff_array[diff_array != 0]}")
+        logging.info(f"DEM array diff is: {diff_array[diff_array != 0]}")
         numpy.testing.assert_array_almost_equal(test_dem.data, benchmark_dem.data,
                                                 err_msg="The generated result_dem has different data from the " +
                                                 "benchmark_dem")
@@ -174,7 +179,7 @@ class ProcessorRemoteTilesWellingtonTest(unittest.TestCase):
 
         # compare the generated and benchmark DEMs
         diff_array = test_dem.data[~numpy.isnan(test_dem.data)]-benchmark_dem.data[~numpy.isnan(benchmark_dem.data)]
-        print(f"DEM array diff is: {diff_array[diff_array != 0]}")
+        logging.info(f"DEM array diff is: {diff_array[diff_array != 0]}")
 
         threshold = 10e-6
         self.assertTrue(len(diff_array[diff_array != 0]) < len(diff_array) / 100, f"{len(diff_array[diff_array != 0])} "

--- a/tests/test_processor_remote_tiles_westport/data/benchmark_dem.nc
+++ b/tests/test_processor_remote_tiles_westport/data/benchmark_dem.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6700ae6cc1e7032756d2bc65714b08d2a714ce8a12ffc07c5907a16692fb034e
+oid sha256:c76f463c6d94344963d84871fec53d9c0958ed8a95d4bc1139cedfa6820a8f8e
 size 186952

--- a/tests/test_processor_remote_tiles_westport/instruction.json
+++ b/tests/test_processor_remote_tiles_westport/instruction.json
@@ -13,7 +13,6 @@
 			"local_cache": "tests/test_processor_remote_tiles_westport/data",
 			"catchment_boundary": "tests/test_processor_remote_tiles_westport/data/catchment.zip",
 			"land": "tests/test_processor_remote_tiles_westport/data/catchment.zip",
-			"temp_raster": "tests/test_processor_remote_tiles_westport/data/temp_dense_dem.tif",
 			"result_dem": "tests/test_processor_remote_tiles_westport/data/test_dem.nc",
 			"dense_dem_extents": "tests/test_processor_remote_tiles_westport/data/extents.geojson",
 			"benchmark_dem": "tests/test_processor_remote_tiles_westport/data/benchmark_dem.nc"
@@ -24,8 +23,7 @@
 		"general": {
 			"set_dem_shoreline": true,
 			"drop_offshore_lidar": false,
-			"keep_only_ground_lidar": false,
-			"interpolate_missing_values": false
+			"keep_only_ground_lidar": false
 		}
 	}
 }

--- a/tests/test_processor_remote_tiles_westport/instruction.json
+++ b/tests/test_processor_remote_tiles_westport/instruction.json
@@ -11,7 +11,7 @@
 		},
 		"processing": {
 			"chunk_size": 100,
-			"number_of_cores": 1
+			"number_of_cores": 2
 		},
 		"data_paths": {
 			"local_cache": "tests/test_processor_remote_tiles_westport/data",

--- a/tests/test_processor_remote_tiles_westport/instruction.json
+++ b/tests/test_processor_remote_tiles_westport/instruction.json
@@ -23,7 +23,8 @@
 		"general": {
 			"set_dem_shoreline": true,
 			"drop_offshore_lidar": false,
-			"keep_only_ground_lidar": false
+			"keep_only_ground_lidar": false,
+			"chunk_size": 100
 		}
 	}
 }

--- a/tests/test_processor_remote_tiles_westport/instruction.json
+++ b/tests/test_processor_remote_tiles_westport/instruction.json
@@ -9,6 +9,10 @@
 				"resolution": 10
 			}
 		},
+		"processing": {
+			"chunk_size": 100,
+			"number_of_cores": 1
+		},
 		"data_paths": {
 			"local_cache": "tests/test_processor_remote_tiles_westport/data",
 			"catchment_boundary": "tests/test_processor_remote_tiles_westport/data/catchment.zip",
@@ -23,8 +27,7 @@
 		"general": {
 			"set_dem_shoreline": true,
 			"drop_offshore_lidar": false,
-			"keep_only_ground_lidar": false,
-			"chunk_size": 100
+			"keep_only_ground_lidar": false
 		}
 	}
 }

--- a/tests/test_processor_remote_tiles_westport/test_processor_remote_tiles_westport.py
+++ b/tests/test_processor_remote_tiles_westport/test_processor_remote_tiles_westport.py
@@ -15,6 +15,7 @@ import numpy
 import rioxarray
 import pytest
 import sys
+import logging
 
 from src.geofabrics import processor
 
@@ -44,6 +45,10 @@ class ProcessorRemoteTilesWestportTest(unittest.TestCase):
         files and produce a DEM prior to testing. """
 
         test_path = pathlib.Path().cwd() / pathlib.Path("tests/test_processor_remote_tiles_westport")
+
+        # Setup logging
+        logging.basicConfig(filename=test_path / 'test.log', encoding='utf-8', level=logging.INFO, force=True)
+        logging.info("In test_processor_remote_tiles_westport.py")
 
         # load in the test instructions
         instruction_file_path = test_path / "instruction.json"
@@ -156,7 +161,7 @@ class ProcessorRemoteTilesWestportTest(unittest.TestCase):
 
         # compare the generated and benchmark DEMs
         diff_array = test_dem.data[~numpy.isnan(test_dem.data)]-benchmark_dem.data[~numpy.isnan(benchmark_dem.data)]
-        print(f"DEM array diff is: {diff_array[diff_array != 0]}")
+        logging.info(f"DEM array diff is: {diff_array[diff_array != 0]}")
         numpy.testing.assert_array_almost_equal(test_dem.data[~numpy.isnan(test_dem.data)],
                                                 benchmark_dem.data[~numpy.isnan(benchmark_dem.data)],
                                                 err_msg="The generated result_dem has different data from the " +
@@ -178,7 +183,7 @@ class ProcessorRemoteTilesWestportTest(unittest.TestCase):
 
         # compare the generated and benchmark DEMs
         diff_array = test_dem.data[~numpy.isnan(test_dem.data)]-benchmark_dem.data[~numpy.isnan(benchmark_dem.data)]
-        print(f"DEM array diff is: {diff_array[diff_array != 0]}")
+        logging.info(f"DEM array diff is: {diff_array[diff_array != 0]}")
 
         threshold = 10e-2
         allowable_number_above = 3

--- a/tests/test_processor_remote_tiles_westport_ground_only/data/benchmark_dem.nc
+++ b/tests/test_processor_remote_tiles_westport_ground_only/data/benchmark_dem.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5bfa1ef423f5c0aef8057fbb86f9909f4da50fae814ac180e7d1217f31280db4
+oid sha256:fdceb1b82934983899cc470029d0a7666012320850801db6e05fcde41e0f48e1
 size 186952

--- a/tests/test_processor_remote_tiles_westport_ground_only/instruction.json
+++ b/tests/test_processor_remote_tiles_westport_ground_only/instruction.json
@@ -13,7 +13,6 @@
 			"local_cache": "tests/test_processor_remote_tiles_westport_ground_only/data",
 			"catchment_boundary": "tests/test_processor_remote_tiles_westport_ground_only/data/catchment.zip",
 			"land": "tests/test_processor_remote_tiles_westport_ground_only/data/catchment.zip",
-			"temp_raster": "tests/test_processor_remote_tiles_westport_ground_only/data/temp_dense_dem.tif",
 			"result_dem": "tests/test_processor_remote_tiles_westport_ground_only/data/test_dem.nc",
 			"dense_dem_extents": "tests/test_processor_remote_tiles_westport_ground_only/data/extents.geojson",
 			"benchmark_dem": "tests/test_processor_remote_tiles_westport_ground_only/data/benchmark_dem.nc"

--- a/tests/test_processor_remote_tiles_westport_ground_only/instruction.json
+++ b/tests/test_processor_remote_tiles_westport_ground_only/instruction.json
@@ -9,6 +9,10 @@
 				"resolution": 10
 			}
 		},
+		"processing": {
+			"chunk_size": 200,
+			"number_of_cores": 1
+		},
 		"data_paths": {
 			"local_cache": "tests/test_processor_remote_tiles_westport_ground_only/data",
 			"catchment_boundary": "tests/test_processor_remote_tiles_westport_ground_only/data/catchment.zip",
@@ -23,8 +27,7 @@
 		"general": {
 			"set_dem_shoreline": true,
 			"drop_offshore_lidar": false,
-			"keep_only_ground_lidar": true,
-			"chunk_size": 200
+			"keep_only_ground_lidar": true
 		}
 	}
 }

--- a/tests/test_processor_remote_tiles_westport_ground_only/instruction.json
+++ b/tests/test_processor_remote_tiles_westport_ground_only/instruction.json
@@ -11,7 +11,7 @@
 		},
 		"processing": {
 			"chunk_size": 200,
-			"number_of_cores": 1
+			"number_of_cores": 2
 		},
 		"data_paths": {
 			"local_cache": "tests/test_processor_remote_tiles_westport_ground_only/data",

--- a/tests/test_processor_remote_tiles_westport_ground_only/instruction.json
+++ b/tests/test_processor_remote_tiles_westport_ground_only/instruction.json
@@ -23,7 +23,8 @@
 		"general": {
 			"set_dem_shoreline": true,
 			"drop_offshore_lidar": false,
-			"keep_only_ground_lidar": true
+			"keep_only_ground_lidar": true,
+			"chunk_size": 200
 		}
 	}
 }

--- a/tests/test_processor_remote_tiles_westport_ground_only/test_processor_remote_tiles_westport_ground_only.py
+++ b/tests/test_processor_remote_tiles_westport_ground_only/test_processor_remote_tiles_westport_ground_only.py
@@ -15,6 +15,7 @@ import numpy
 import rioxarray
 import pytest
 import sys
+import logging
 
 from src.geofabrics import processor
 
@@ -49,6 +50,10 @@ class ProcessorRemoteTilesWestportTest(unittest.TestCase):
         files and produce a DEM prior to testing. """
 
         test_path = pathlib.Path().cwd() / pathlib.Path("tests/test_processor_remote_tiles_westport_ground_only")
+
+        # Setup logging
+        logging.basicConfig(filename=test_path / 'test.log', encoding='utf-8', level=logging.INFO, force=True)
+        logging.info("In test_processor_remote_tiles_wellington_ground_only.py")
 
         # Load in the test instructions
         instruction_file_path = test_path / "instruction.json"
@@ -161,7 +166,7 @@ class ProcessorRemoteTilesWestportTest(unittest.TestCase):
 
         # Compare the generated and benchmark DEMs
         diff_array = test_dem.data[~numpy.isnan(test_dem.data)]-benchmark_dem.data[~numpy.isnan(benchmark_dem.data)]
-        print(f"DEM array diff is: {diff_array[diff_array != 0]}")
+        logging.info(f"DEM array diff is: {diff_array[diff_array != 0]}")
         numpy.testing.assert_array_almost_equal(test_dem.data[~numpy.isnan(test_dem.data)],
                                                 benchmark_dem.data[~numpy.isnan(benchmark_dem.data)],
                                                 err_msg="The generated result_dem has different data from the " +
@@ -183,7 +188,7 @@ class ProcessorRemoteTilesWestportTest(unittest.TestCase):
 
         # Compare the generated and benchmark DEMs
         diff_array = test_dem.data[~numpy.isnan(test_dem.data)]-benchmark_dem.data[~numpy.isnan(benchmark_dem.data)]
-        print(f"DEM array diff is: {diff_array[diff_array != 0]}")
+        logging.info(f"DEM array diff is: {diff_array[diff_array != 0]}")
 
         threshold = 10e-2
         allowable_number_above = 38

--- a/tests/test_processor_remote_tiles_westport_ground_only/test_processor_remote_tiles_westport_ground_only.py
+++ b/tests/test_processor_remote_tiles_westport_ground_only/test_processor_remote_tiles_westport_ground_only.py
@@ -186,14 +186,14 @@ class ProcessorRemoteTilesWestportTest(unittest.TestCase):
         print(f"DEM array diff is: {diff_array[diff_array != 0]}")
 
         threshold = 10e-2
-        allowable_number_above = 13
-        self.assertTrue(len(diff_array[numpy.abs(diff_array) > threshold]) <= allowable_number_above, "Some DEM values "
-                        + f"differ by more than {threshold} on Linux test run: " +
-                        f"{diff_array[numpy.abs(diff_array) > threshold]}")
+        allowable_number_above = 38
+        self.assertTrue(len(diff_array[numpy.abs(diff_array) > threshold]) <= allowable_number_above, "A total of "
+                        f"len(diff_array[numpy.abs(diff_array) > threshold]) DEM values differ by more than {threshold}"
+                        f" on Linux test run: {diff_array[numpy.abs(diff_array) > threshold]}")
         threshold = 10e-6
         self.assertTrue(len(diff_array[numpy.abs(diff_array) > threshold]) < len(diff_array) / 100,
                         f"{len(diff_array[numpy.abs(diff_array) > threshold])} or more than 1% of DEM values differ by"
-                        + f" more than {threshold} on Linux test run: {diff_array[numpy.abs(diff_array) > threshold]}")
+                        f" more than {threshold} on Linux test run: {diff_array[numpy.abs(diff_array) > threshold]}")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Generate DEM in chunks and used Dask to allow this to be done in parallel in a distributed system.

 - [x] Make code change - still need to set the number of workers based on the instruction file
 - [x] Update tests 
   - [x] Update / create new tests
   - [x] Ensure these tests have the expected behavour
   - [x] Test locally and ensure tests are passing
 - [x] Ensure tests passing on GH Actions
 - [x] Update documentation
   - [x] Doc strings
   - [x] Wiki 
  - [x] Update package version (if needed) 

From the review:
- [x] Using the builtin Python logging module
- [x] Avoid delayed as a decorator - cleaner interface as suggested
- [x] Move the dask client creation to a higher level so it is more visible
- [x] Look into removing the explicit compute call and instead saving the dense_dem to disk prior to an later steps - have created as an issue. See issue notes.