### PR TITLE
110 bug fiix ensure no holes are left after linear interpolation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,7 @@ celerybeat.pid
 
 # Environments
 .env
+.env.b64
 .venv
 env/
 venv/

--- a/src/geofabrics/dem.py
+++ b/src/geofabrics/dem.py
@@ -430,6 +430,9 @@ class HydrologicallyConditionedDem(DemBase):
             self._dem["z"] = self._dem.z.rio.interpolate_na(
                 method=self.interpolation_method
             )
+            # If any NaN remain apply nearest neighbour interpolation
+            if numpy.isnan(self._dem.z.data).any():
+                self._dem["z"] = self._dem.z.rio.interpolate_na(method="nearest")
             # Only set areas with successful interpolation as interpolated
             interpolation_mask &= numpy.logical_not(numpy.isnan(self._dem.z.data))
             self._dem.source_class.data[
@@ -1895,6 +1898,9 @@ class RoughnessDem(LidarBase):
             self._dem["zo"] = self._dem.zo.rio.interpolate_na(
                 method=self.interpolation_method
             )
+            # If any NaN remain apply nearest neighbour interpolation
+            if numpy.isnan(self._dem.z.data).any():
+                self._dem["zo"] = self._dem.zo.rio.interpolate_na(method="nearest")
         self._dem = self._dem.rio.clip(
             self.catchment_geometry.catchment.geometry, drop=True
         )

--- a/src/geofabrics/version.py
+++ b/src/geofabrics/version.py
@@ -3,4 +3,4 @@
 Contains the package version information
 """
 
-__version__ = "0.9.9"
+__version__ = "0.9.10"

--- a/tests/test_processor_remote_tiles_wellington/data/benchmark_dem.nc
+++ b/tests/test_processor_remote_tiles_wellington/data/benchmark_dem.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e7b0f7c03ec1fd15da6fd0177a358c1c3f6e0bad2897931f2196f62ac2072c3f
-size 83139
+oid sha256:336b2b79caf9846fd14c74b0c9737d984ecdaeaff7636f440ec8a738d29a82d1
+size 83111


### PR DESCRIPTION
If interpolation is selected - follow with Nearest Neighbour interpolation if any NaNs remain to perform extrapolation (both Linear and cubic struggle to interpolate around the edges):
 - [x] Make code change
 - [x] Update tests 
   - [x] Update / create new tests
   - [x] Ensure these tests have the expected behaviour
   - [x] Test locally and ensure tests are passing
 - [x] Ensure tests passing on GH Actions
 - [x] Update documentation
   - [x] Doc strings
   - [x] Wiki 
  - [x] Update package version (if needed) 
