### PR TITLE
163 add support for multiple local lidar dataset

### DIFF
--- a/src/geofabrics/processor.py
+++ b/src/geofabrics/processor.py
@@ -570,13 +570,17 @@ class BaseProcessor(abc.ABC):
                     / f"{dataset_name}_TileIndex.zip"
                 )
         else:
-            # get the specified file paths from the instructions,
-            lidar_datasets_info["local_files"] = {}
-            lidar_datasets_info["local_files"][
-                "file_paths"
-            ] = self.get_instruction_path("lidars")
-            lidar_datasets_info["local_files"]["crs"] = None
-            lidar_datasets_info["local_files"]["tile_index_file"] = None
+            # for multiple local lidar datasets
+            if 'local' in self.instructions.keys() and 'lidar' in self.instructions['local'].keys():
+                lidar_datasets_info = self.instructions["local"]["lidar"]
+            else:
+                # get the specified file paths from the instructions,
+                lidar_datasets_info["local_files"] = {}
+                lidar_datasets_info["local_files"][
+                    "file_paths"
+                ] = self.get_instruction_path("lidars")
+                lidar_datasets_info["local_files"]["crs"] = None
+                lidar_datasets_info["local_files"]["tile_index_file"] = None
         return lidar_datasets_info
 
     def create_catchment(self) -> geometry.CatchmentGeometry:


### PR DESCRIPTION
Current `lidar_dataset_info` (`get_lidar_datasets_info()` in `processor.py`) for local files does not support multiple datasets. If we define the instructions dictionary like the below example and pass it to `lidar_dataset_info` like: `lidar_datasets_info = self.instructions["local"]["lidar"]`, it will support multiple local datasets in the same way with API enabled process.

The contents of `instructions["local"]["lidar"]` are identical (ideally, may vary case by case) the same as the contents in `lidar_dataset_info`.
 while using API.


1. only need to define the corresponding dict in the instructions file, as the below example shows.
1. compatible with old test cases.

```
...
    "apis": {}
    "local": {
      "lidar": {
        "NZ20_Cant2": {
          "crs": {
            "horizontal": 2193,
            "vertical": 7839
          },
          "file_paths": [
            "../datastorage/LiDAR/NZ20_Cant2/CL2_BW24_2020_1000_0229.laz",
            ...
            "../datastorage/LiDAR/NZ20_Cant2/CL2_BW24_2020_1000_1230.laz",
          "tile_index_file": "../datastorage/LiDAR/NZ20_Cant2/NZ20_Cant2_TileIndex.zip"
        },
        "NZ18_AmuriCant": {
          "crs": {
            "horizontal": 2193,
            "vertical": 7839
          },
          "file_paths": [
            "../datastorage/LiDAR/NZ18_AmuriCant/CL2_BW24_2018_1000_0739.laz",
            ...
            "../datastorage/LiDAR/NZ18_AmuriCant/CL2_BW24_2018_1000_0838.laz",
          "tile_index_file": "../datastorage/LiDAR/NZ18_AmuriCant/NZ18_AmuriCant_TileIndex.zip"
        },
...
```

DESCRIPTION OF PR:
 - [x] Make code change
 - [x] Tests, version and documentation to be updated on upstream branch
