### PR TITLE
246 fix error when invalid waterways geometry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "geofabrics"
-version = "1.1.11"
+version = "1.1.12"
 description = "A package for creating geofabrics for flood modelling."
 readme = "README.md"
 authors = [{ name = "Rose pearson", email = "rose.pearson@niwa.co.nz" }]

--- a/src/geofabrics/dem.py
+++ b/src/geofabrics/dem.py
@@ -1267,6 +1267,7 @@ class LidarBase(DemBase):
 
         dem = self._dem
         self.save_dem(filename=filename, dem=dem)
+        del dem, self._dem
         dem = self._load_dem(filename=filename)
         self._dem = dem
 

--- a/src/geofabrics/processor.py
+++ b/src/geofabrics/processor.py
@@ -984,7 +984,6 @@ class RawLidarDemGenerator(BaseProcessor):
                     "complevel": 1,
                 },
             }
-            encoding = None  # Separately test compressing final netCDF outputs
             self.raw_dem.save_dem(
                 self.get_instruction_path("raw_dem"),
                 dem=self.raw_dem.dem,
@@ -1395,7 +1394,6 @@ class RoughnessLengthGenerator(BaseProcessor):
                     "complevel": 1,
                 },
             }
-            encoding = None  # Separately test compressing final netCDF outputs
             self.roughness_dem.save_dem(
                 filename=self.get_instruction_path("result_geofabric"),
                 dem=self.roughness_dem.dem,

--- a/src/geofabrics/processor.py
+++ b/src/geofabrics/processor.py
@@ -2806,9 +2806,9 @@ class WaterwayBedElevationEstimator(BaseProcessor):
         if polygon_file.is_file() and elevation_file.is_file():
             self.logger.info("Open waterways already recorded. ")
             return
-        # If not - estimate the elevations along the open waterways
+        # If not - estimate the elevations along the open waterways - drop any invalid geometries
         open_waterways = waterways[numpy.logical_not(waterways["tunnel"])]
-
+        open_waterways = open_waterways[~open_waterways.geometry.isna()]
         # sample the ends of the waterway - sample over a polygon at each end
         polygons = open_waterways.interpolate(0).buffer(open_waterways["width"])
         open_waterways["start_elevation"] = polygons.apply(

--- a/src/geofabrics/processor.py
+++ b/src/geofabrics/processor.py
@@ -933,7 +933,7 @@ class RawLidarDemGenerator(BaseProcessor):
                 temp_file = temp_folder / "raw_lidar_clipped.nc"
                 self.logger.info(f"Save temp raw DEM to netCDF: {temp_file}")
                 self.raw_dem.save_and_load_dem(temp_file)
-    
+
                 # Remove previous cached file and replace with new one
                 cached_file.unlink()
                 cached_file = temp_file

--- a/src/geofabrics/version.py
+++ b/src/geofabrics/version.py
@@ -3,4 +3,4 @@
 Contains the package version information
 """
 
-__version__ = "1.1.11"
+__version__ = "1.1.12"

--- a/tests/test_dem_generation_local_1/data/benchmark_dem.nc
+++ b/tests/test_dem_generation_local_1/data/benchmark_dem.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f345c78987f5b8650b25f3e2139e8d66b1f2a03f3e630bcfd7fcff1b05134a3e
-size 186019
+oid sha256:c0d05b79140efbd039366db0cef42962108220df61bd75585860f2562dcf5b9f
+size 50917


### PR DESCRIPTION
Fixes:
* Fixes TB when invalid waterways geometry
* Add option of not clipping the raw LiDAR DEM - set as defaul when called from waterways stage. Reduces processing
* Force garbage collection of cached DEMs - described in https://github.com/rosepearson/GeoFabrics/issues/231
* Turn on compression of save netCDF files - described in https://github.com/rosepearson/GeoFabrics/issues/236
 - [x] Make code change
 - [x] Update tests
   - [x] Update / create new tests
   - [x] Ensure these tests have the expected behavour
   - [x] Test locally and ensure tests are passing
 - [x] Ensure tests passing on GH Actions
 - [x] Update documentation
   - [x] Doc strings
   - [x] Wiki
- [x] Update package (version.py & pyproject.toml) version (if needed)
